### PR TITLE
Reworking the Editor to be much more performant by re-imagining its use

### DIFF
--- a/DragonQuestinoEditor/DragonQuestinoEditor/FileOps/TileMapFileOps.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/FileOps/TileMapFileOps.cs
@@ -32,7 +32,7 @@ namespace DragonQuestinoEditor.FileOps
 
          foreach ( var tile in mapTiles )
          {
-            tile.SetIndex( tileIndexes[i] );
+            tile.Index = tileIndexes[i];
             i++;
          }
 

--- a/DragonQuestinoEditor/DragonQuestinoEditor/Graphics/Sprite.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/Graphics/Sprite.cs
@@ -57,6 +57,22 @@ namespace DragonQuestinoEditor.Graphics
          return _pixels[x, y];
       }
 
+      public Sprite Extract( int x, int y, int width, int height )
+      {
+         var newSprite = new Sprite( width, height );
+
+         for (int row = 0; row < height; row++)
+         {
+            for (int col = 0; col < width; col++)
+            {
+               var srcPixel = GetPixel( col + x, row + y );
+               newSprite.SetPixel( col, row, srcPixel );
+            }
+         }
+
+         return newSprite;
+      }
+
       private byte[] ConvertToLinearBuffer()
       {
          var linearPixelBuffer = new byte[_pixels.Length * 4];

--- a/DragonQuestinoEditor/DragonQuestinoEditor/Graphics/Sprite.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/Graphics/Sprite.cs
@@ -1,0 +1,93 @@
+﻿using System.IO;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace DragonQuestinoEditor.Graphics
+{
+   internal class Sprite
+   {
+      private readonly Color[,] _pixels;
+
+      public int Width { get; }
+      public int Height { get; }
+
+      public Sprite( int width, int height )
+      {
+         Width = width;
+         Height = height;
+
+         _pixels = new Color[width, height];
+      }
+
+      public static Sprite LoadFromFile( string path )
+      {
+         using var fileStream = new FileStream( path, FileMode.Open, FileAccess.Read );
+         var decoder = new PngBitmapDecoder( fileStream, BitmapCreateOptions.PreservePixelFormat, BitmapCacheOption.Default );
+         var bitmapFrame = decoder.Frames[0];
+
+         int stride = bitmapFrame.PixelWidth * bitmapFrame.Format.BitsPerPixel / 8;
+
+         var data = new byte[stride * bitmapFrame.PixelHeight];
+         bitmapFrame.CopyPixels( data, stride, 0 );
+
+         var sprite = new Sprite( bitmapFrame.PixelWidth, bitmapFrame.PixelHeight );
+         int sourceOffset = 0;
+
+         for (int y = 0; y < bitmapFrame.PixelHeight; y++)
+         {
+            for (int x = 0; x < bitmapFrame.PixelWidth; x++)
+            {
+               int pixelIndex = data[sourceOffset++];
+               var color = bitmapFrame.Palette.Colors[pixelIndex];
+               sprite.SetPixel( x, y, color );
+            }
+         }
+
+         return sprite;
+      }
+
+      public void SetPixel( int x, int y, Color color )
+      {
+         _pixels[x, y] = color;
+      }
+
+      public Color GetPixel( int x, int y )
+      {
+         return _pixels[x, y];
+      }
+
+      private byte[] ConvertToLinearBuffer()
+      {
+         var linearPixelBuffer = new byte[_pixels.Length * 4];
+         int offset = 0;
+
+         for (int y = 0; y < Height; y++)
+         {
+            for (int x = 0; x < Width; x++)
+            {
+               linearPixelBuffer[offset++] = _pixels[x, y].B;
+               linearPixelBuffer[offset++] = _pixels[x, y].G;
+               linearPixelBuffer[offset++] = _pixels[x, y].R;
+               linearPixelBuffer[offset++] = _pixels[x, y].A;
+            }
+         }
+
+         return linearPixelBuffer;
+      }
+
+      public void SaveAsPng( string path )
+      {
+         var linearPixelBuffer = ConvertToLinearBuffer();
+
+         var writableBitmap = new WriteableBitmap( Width, Height, 96, 96, PixelFormats.Bgra32, null );
+         writableBitmap.WritePixels( new Int32Rect( 0, 0, Width, Height ), linearPixelBuffer, Width * 4, 0 );
+
+         using var fileStream = new FileStream( path, FileMode.Create, FileAccess.Write );
+
+         var encoder = new PngBitmapEncoder();
+         encoder.Frames.Add( BitmapFrame.Create( writableBitmap ) );
+         encoder.Save( fileStream );
+      }
+   }
+}

--- a/DragonQuestinoEditor/DragonQuestinoEditor/Graphics/Sprite.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/Graphics/Sprite.cs
@@ -73,6 +73,26 @@ namespace DragonQuestinoEditor.Graphics
          return newSprite;
       }
 
+      public void DrawToBuffer( byte[] buffer, int bufferWidth, int x, int y )
+      {
+         for (int row = 0; row < Height; row++)
+         {
+            for (int col = 0; col < Width; col++)
+            {
+               var pixel = GetPixel( col, row );
+
+               int destX = x + col * 4;
+               int destY = y + row;
+               int offset = destY * bufferWidth + destX;
+
+               buffer[offset + 0] = pixel.B;
+               buffer[offset + 1] = pixel.G;
+               buffer[offset + 2] = pixel.R;
+               buffer[offset + 3] = pixel.A;
+            }
+         }
+      }
+
       private byte[] ConvertToLinearBuffer()
       {
          var linearPixelBuffer = new byte[_pixels.Length * 4];

--- a/DragonQuestinoEditor/DragonQuestinoEditor/Graphics/TileSet.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/Graphics/TileSet.cs
@@ -9,10 +9,12 @@ namespace DragonQuestinoEditor.Graphics
    {
       private readonly List<WriteableBitmap> _tileBitmaps = new( Constants.TileCount );
       private readonly Palette _palette;
+      private readonly Sprite[] _tiles = new Sprite[Constants.TileCount];
 
       public List<List<int>> TilePaletteIndexes = new ( Constants.TileCount );
 
       public List<WriteableBitmap> TileBitmaps => _tileBitmaps;
+      public Sprite[] Tiles => _tiles;
 
       public TileSet( string imagePath, Palette palette )
       {
@@ -21,9 +23,24 @@ namespace DragonQuestinoEditor.Graphics
          var textFileStream = new FileStream( imagePath, FileMode.Open, FileAccess.Read, FileShare.Read );
          var textDecoder = new PngBitmapDecoder( textFileStream, BitmapCreateOptions.PreservePixelFormat, BitmapCacheOption.Default );
          var bitmapSource = textDecoder.Frames[0];
+
          BitmapUtils.CheckTileSetBitmapFormat( bitmapSource );
          ReadTileBitmaps( bitmapSource );
          UpdatePalette();
+
+         // Extract the tiles as sprites
+
+         var tileSheet = Sprite.LoadFromFile( imagePath );
+         int tileCount = tileSheet.Width / Constants.TileSize;
+
+         for (int tileIndex = 0; tileIndex < tileCount; tileIndex++)
+         {
+            int srcX = tileIndex * Constants.TileSize;
+            int srcY = 0;
+
+            var tileSprite = tileSheet.Extract( srcX, srcY, Constants.TileSize, Constants.TileSize );
+            _tiles[tileIndex] = tileSprite;
+         }
       }
 
       private void ReadTileBitmaps( BitmapSource bitmapSource )

--- a/DragonQuestinoEditor/DragonQuestinoEditor/InputMode.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/InputMode.cs
@@ -1,0 +1,8 @@
+﻿namespace DragonQuestinoEditor
+{
+   internal enum InputMode
+   {
+      Draw,
+      Pan
+   }
+}

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
@@ -31,10 +31,14 @@
                                                                    FalseValue="Collapsed" />
       </ResourceDictionary>
    </Window.Resources>
-   <StackPanel Orientation="Horizontal">
+
+   <Grid>
+      <Grid.ColumnDefinitions>
+         <ColumnDefinition Width="Auto" />
+         <ColumnDefinition />
+      </Grid.ColumnDefinitions>
 
       <StackPanel>
-
          <!-- Tile Picker -->
          <ListView x:Name="tileSelectionListView"
                    ItemsSource="{Binding TileSelectionViewModels}"
@@ -61,11 +65,11 @@
                  Command="{Binding SaveTileMapCommand, Mode=OneTime}" />
          <Button Content="Write File"
                  Command="{Binding WriteFileCommand, Mode=OneTime}" />
-
       </StackPanel>
 
       <!-- Tile Map -->
       <ListView x:Name="tileMapListView"
+                Grid.Column="1"
                 ItemsSource="{Binding TileMapViewModels}"
                 VerticalAlignment="Top"
                 HorizontalAlignment="Left"
@@ -96,6 +100,5 @@
             </DataTemplate>
          </ListView.ItemTemplate>
       </ListView>
-
-   </StackPanel>
+   </Grid>
 </Window>

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
@@ -31,73 +31,71 @@
                                                                    FalseValue="Collapsed" />
       </ResourceDictionary>
    </Window.Resources>
-   <Grid>
-      <StackPanel Orientation="Horizontal">
+   <StackPanel Orientation="Horizontal">
 
-         <StackPanel>
+      <StackPanel>
 
-            <!-- Tile Picker -->
-            <ListView x:Name="tileSelectionListView"
-                      ItemsSource="{Binding TileSelectionViewModels}"
-                      VerticalAlignment="Top"
-                      HorizontalAlignment="Left"
-                      ItemContainerStyle="{StaticResource TileListItemContainerStyle}"
-                      MouseMove="TileSelectionListView_OnMouseMove">
-               <ItemsControl.ItemsPanel>
-                  <ItemsPanelTemplate>
-                     <UniformGrid Columns="4" />
-                  </ItemsPanelTemplate>
-               </ItemsControl.ItemsPanel>
-               <ListView.ItemTemplate>
-                  <DataTemplate>
-                     <Image Source="{Binding Image}"
-                            Width="32"
-                            Height="32" />
-                  </DataTemplate>
-               </ListView.ItemTemplate>
-            </ListView>
-
-            <!-- Control Panel -->
-            <Button Content="Save Tile Map"
-                    Command="{Binding SaveTileMapCommand, Mode=OneTime}" />
-            <Button Content="Write File"
-                    Command="{Binding WriteFileCommand, Mode=OneTime}" />
-
-         </StackPanel>
-
-         <!-- Tile Map -->
-         <ListView x:Name="tileMapListView"
-                   ItemsSource="{Binding TileMapViewModels}"
+         <!-- Tile Picker -->
+         <ListView x:Name="tileSelectionListView"
+                   ItemsSource="{Binding TileSelectionViewModels}"
                    VerticalAlignment="Top"
                    HorizontalAlignment="Left"
-                   Width="1120"
-                   Height="760"
                    ItemContainerStyle="{StaticResource TileListItemContainerStyle}"
-                   AllowDrop="True"
-                   PreviewMouseDown="TileMapListView_OnPreviewMouseDown"
-                   MouseMove="TileMapListView_OnMouseMove"
-                   Drop="TileMapListView_OnDrop">
+                   MouseMove="TileSelectionListView_OnMouseMove">
             <ItemsControl.ItemsPanel>
                <ItemsPanelTemplate>
-                  <UniformGrid Columns="140" />
+                  <UniformGrid Columns="4" />
                </ItemsPanelTemplate>
             </ItemsControl.ItemsPanel>
             <ListView.ItemTemplate>
                <DataTemplate>
-                  <Grid DragEnter="TileMapListViewImage_OnDragEnter"
-                        DragLeave="TileMapListViewImage_OnDragLeave">
-                     <Image Source="{Binding Image}"
-                            Width="32"
-                            Height="32" />
-                     <Rectangle Width="32"
-                                Height="32"
-                                Fill="#660000FF"
-                                Visibility="{Binding ShouldHighlight, Converter={StaticResource BoolToVisibilityConverter}}" />
-                  </Grid>
+                  <Image Source="{Binding Image}"
+                         Width="32"
+                         Height="32" />
                </DataTemplate>
             </ListView.ItemTemplate>
          </ListView>
 
+         <!-- Control Panel -->
+         <Button Content="Save Tile Map"
+                 Command="{Binding SaveTileMapCommand, Mode=OneTime}" />
+         <Button Content="Write File"
+                 Command="{Binding WriteFileCommand, Mode=OneTime}" />
+
       </StackPanel>
-   </Grid>
+
+      <!-- Tile Map -->
+      <ListView x:Name="tileMapListView"
+                ItemsSource="{Binding TileMapViewModels}"
+                VerticalAlignment="Top"
+                HorizontalAlignment="Left"
+                Width="1120"
+                Height="760"
+                ItemContainerStyle="{StaticResource TileListItemContainerStyle}"
+                AllowDrop="True"
+                PreviewMouseDown="TileMapListView_OnPreviewMouseDown"
+                MouseMove="TileMapListView_OnMouseMove"
+                Drop="TileMapListView_OnDrop">
+         <ItemsControl.ItemsPanel>
+            <ItemsPanelTemplate>
+               <UniformGrid Columns="140" />
+            </ItemsPanelTemplate>
+         </ItemsControl.ItemsPanel>
+         <ListView.ItemTemplate>
+            <DataTemplate>
+               <Grid DragEnter="TileMapListViewImage_OnDragEnter"
+                     DragLeave="TileMapListViewImage_OnDragLeave">
+                  <Image Source="{Binding Image}"
+                         Width="32"
+                         Height="32" />
+                  <Rectangle Width="32"
+                             Height="32"
+                             Fill="#660000FF"
+                             Visibility="{Binding ShouldHighlight, Converter={StaticResource BoolToVisibilityConverter}}" />
+               </Grid>
+            </DataTemplate>
+         </ListView.ItemTemplate>
+      </ListView>
+
+   </StackPanel>
 </Window>

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
@@ -9,7 +9,8 @@
         Title="Dragon Questino Editor"
         Height="800"
         Width="1280"
-        ResizeMode="NoResize">
+        ResizeMode="NoResize"
+        FocusManager.FocusedElement="{Binding ElementName=MapPanel}">
    <Window.Resources>
       <ResourceDictionary>
          <Style x:Key="TileListItemContainerStyle"
@@ -68,7 +69,8 @@
       </StackPanel>
 
       <!-- Tile Map -->
-      <local:MapPanel Grid.Column="1"
+      <local:MapPanel x:Name="MapPanel"
+                      Grid.Column="1"
                       TileMap="{Binding TileMapViewModels}" />
 
       <!--<ListView x:Name="tileMapListView"

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
@@ -12,11 +12,9 @@
         ResizeMode="NoResize"
         FocusManager.FocusedElement="{Binding ElementName=MapPanel}">
    <Window.Resources>
-      <ResourceDictionary>
-         <DragonQuestinoEditorConverters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"
-                                                                   TrueValue="Visible"
-                                                                   FalseValue="Collapsed" />
-      </ResourceDictionary>
+      <DragonQuestinoEditorConverters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"
+                                                                TrueValue="Visible"
+                                                                FalseValue="Collapsed" />
    </Window.Resources>
 
    <Grid>
@@ -40,7 +38,7 @@
 
             <ListBox.ItemTemplate>
                <DataTemplate>
-                  <Image Source="{Binding Image}"
+                  <Image Source="{Binding Image, Mode=OneTime}"
                          Width="32"
                          Height="32" />
                </DataTemplate>
@@ -59,38 +57,5 @@
                       Grid.Column="1"
                       SelectedPaintingIndex="{Binding SelectedItem.Index, ElementName=tileSelectionListView, Mode=TwoWay}"
                       TileMap="{Binding TileMapViewModels}" />
-
-      <!--<ListView x:Name="tileMapListView"
-                Grid.Column="1"
-                ItemsSource="{Binding TileMapViewModels}"
-                VerticalAlignment="Top"
-                HorizontalAlignment="Left"
-                Width="1120"
-                Height="760"
-                ItemContainerStyle="{StaticResource TileListItemContainerStyle}"
-                AllowDrop="True"
-                PreviewMouseDown="TileMapListView_OnPreviewMouseDown"
-                MouseMove="TileMapListView_OnMouseMove"
-                Drop="TileMapListView_OnDrop">
-         <ItemsControl.ItemsPanel>
-            <ItemsPanelTemplate>
-               <UniformGrid Columns="140" />
-            </ItemsPanelTemplate>
-         </ItemsControl.ItemsPanel>
-         <ListView.ItemTemplate>
-            <DataTemplate>
-               <Grid DragEnter="TileMapListViewImage_OnDragEnter"
-                     DragLeave="TileMapListViewImage_OnDragLeave">
-                  <Image Source="{Binding Image}"
-                         Width="32"
-                         Height="32" />
-                  <Rectangle Width="32"
-                             Height="32"
-                             Fill="#660000FF"
-                             Visibility="{Binding ShouldHighlight, Converter={StaticResource BoolToVisibilityConverter}}" />
-               </Grid>
-            </DataTemplate>
-         </ListView.ItemTemplate>
-      </ListView>-->
    </Grid>
 </Window>

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
@@ -13,20 +13,6 @@
         FocusManager.FocusedElement="{Binding ElementName=MapPanel}">
    <Window.Resources>
       <ResourceDictionary>
-         <Style x:Key="TileListItemContainerStyle"
-                TargetType="{x:Type ListViewItem}">
-            <Setter Property="Background"
-                    Value="Transparent" />
-            <Setter Property="FocusVisualStyle"
-                    Value="{x:Null}" />
-            <Setter Property="Template">
-               <Setter.Value>
-                  <ControlTemplate TargetType="{x:Type ListViewItem}">
-                     <ContentPresenter />
-                  </ControlTemplate>
-               </Setter.Value>
-            </Setter>
-         </Style>
          <DragonQuestinoEditorConverters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"
                                                                    TrueValue="Visible"
                                                                    FalseValue="Collapsed" />
@@ -41,25 +27,41 @@
 
       <StackPanel>
          <!-- Tile Picker -->
-         <ListView x:Name="tileSelectionListView"
-                   ItemsSource="{Binding TileSelectionViewModels}"
-                   VerticalAlignment="Top"
-                   HorizontalAlignment="Left"
-                   ItemContainerStyle="{StaticResource TileListItemContainerStyle}"
-                   MouseMove="TileSelectionListView_OnMouseMove">
-            <ItemsControl.ItemsPanel>
+         <ListBox x:Name="tileSelectionListView"
+                  ItemsSource="{Binding TileSelectionViewModels}"
+                  VerticalAlignment="Top"
+                  HorizontalAlignment="Left"
+                  MouseMove="TileSelectionListView_OnMouseMove">
+            <ListBox.ItemsPanel>
                <ItemsPanelTemplate>
                   <UniformGrid Columns="4" />
                </ItemsPanelTemplate>
-            </ItemsControl.ItemsPanel>
-            <ListView.ItemTemplate>
+            </ListBox.ItemsPanel>
+
+            <ListBox.ItemTemplate>
                <DataTemplate>
                   <Image Source="{Binding Image}"
                          Width="32"
                          Height="32" />
                </DataTemplate>
-            </ListView.ItemTemplate>
-         </ListView>
+            </ListBox.ItemTemplate>
+
+            <ListBox.ItemContainerStyle>
+               <Style TargetType="{x:Type ListBoxItem}">
+                  <Setter Property="Background"
+                          Value="Transparent" />
+                  <Setter Property="FocusVisualStyle"
+                          Value="{x:Null}" />
+                  <Setter Property="Template">
+                     <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type ListBoxItem}">
+                           <ContentPresenter />
+                        </ControlTemplate>
+                     </Setter.Value>
+                  </Setter>
+               </Style>
+            </ListBox.ItemContainerStyle>
+         </ListBox>
 
          <!-- Control Panel -->
          <Button Content="Save Tile Map"

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
@@ -16,7 +16,8 @@
                 TargetType="{x:Type ListViewItem}">
             <Setter Property="Background"
                     Value="Transparent" />
-            <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+            <Setter Property="FocusVisualStyle"
+                    Value="{x:Null}" />
             <Setter Property="Template">
                <Setter.Value>
                   <ControlTemplate TargetType="{x:Type ListViewItem}">
@@ -32,9 +33,9 @@
    </Window.Resources>
    <Grid>
       <StackPanel Orientation="Horizontal">
-         
+
          <StackPanel>
-            
+
             <!-- Tile Picker -->
             <ListView x:Name="tileSelectionListView"
                       ItemsSource="{Binding TileSelectionViewModels}"
@@ -44,23 +45,23 @@
                       MouseMove="TileSelectionListView_OnMouseMove">
                <ItemsControl.ItemsPanel>
                   <ItemsPanelTemplate>
-                     <UniformGrid Columns="4"/>
+                     <UniformGrid Columns="4" />
                   </ItemsPanelTemplate>
                </ItemsControl.ItemsPanel>
                <ListView.ItemTemplate>
                   <DataTemplate>
                      <Image Source="{Binding Image}"
                             Width="32"
-                            Height="32"/>
+                            Height="32" />
                   </DataTemplate>
                </ListView.ItemTemplate>
             </ListView>
-            
+
             <!-- Control Panel -->
             <Button Content="Save Tile Map"
-                    Command="{Binding SaveTileMapCommand, Mode=OneTime}"/>
+                    Command="{Binding SaveTileMapCommand, Mode=OneTime}" />
             <Button Content="Write File"
-                    Command="{Binding WriteFileCommand, Mode=OneTime}"/>
+                    Command="{Binding WriteFileCommand, Mode=OneTime}" />
 
          </StackPanel>
 
@@ -78,7 +79,7 @@
                    Drop="TileMapListView_OnDrop">
             <ItemsControl.ItemsPanel>
                <ItemsPanelTemplate>
-                  <UniformGrid Columns="140"/>
+                  <UniformGrid Columns="140" />
                </ItemsPanelTemplate>
             </ItemsControl.ItemsPanel>
             <ListView.ItemTemplate>
@@ -87,16 +88,16 @@
                         DragLeave="TileMapListViewImage_OnDragLeave">
                      <Image Source="{Binding Image}"
                             Width="32"
-                            Height="32"/>
+                            Height="32" />
                      <Rectangle Width="32"
                                 Height="32"
                                 Fill="#660000FF"
-                                Visibility="{Binding ShouldHighlight, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                Visibility="{Binding ShouldHighlight, Converter={StaticResource BoolToVisibilityConverter}}" />
                   </Grid>
                </DataTemplate>
             </ListView.ItemTemplate>
          </ListView>
-         
+
       </StackPanel>
    </Grid>
 </Window>

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
@@ -68,7 +68,10 @@
       </StackPanel>
 
       <!-- Tile Map -->
-      <ListView x:Name="tileMapListView"
+      <local:MapPanel Grid.Column="1"
+                      TileMap="{Binding TileMapViewModels}" />
+
+      <!--<ListView x:Name="tileMapListView"
                 Grid.Column="1"
                 ItemsSource="{Binding TileMapViewModels}"
                 VerticalAlignment="Top"
@@ -99,6 +102,6 @@
                </Grid>
             </DataTemplate>
          </ListView.ItemTemplate>
-      </ListView>
+      </ListView>-->
    </Grid>
 </Window>

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
@@ -45,22 +45,6 @@
                          Height="32" />
                </DataTemplate>
             </ListBox.ItemTemplate>
-
-            <ListBox.ItemContainerStyle>
-               <Style TargetType="{x:Type ListBoxItem}">
-                  <Setter Property="Background"
-                          Value="Transparent" />
-                  <Setter Property="FocusVisualStyle"
-                          Value="{x:Null}" />
-                  <Setter Property="Template">
-                     <Setter.Value>
-                        <ControlTemplate TargetType="{x:Type ListBoxItem}">
-                           <ContentPresenter />
-                        </ControlTemplate>
-                     </Setter.Value>
-                  </Setter>
-               </Style>
-            </ListBox.ItemContainerStyle>
          </ListBox>
 
          <!-- Control Panel -->
@@ -73,6 +57,7 @@
       <!-- Tile Map -->
       <local:MapPanel x:Name="MapPanel"
                       Grid.Column="1"
+                      SelectedPaintingIndex="{Binding SelectedItem.Index, ElementName=tileSelectionListView, Mode=TwoWay}"
                       TileMap="{Binding TileMapViewModels}" />
 
       <!--<ListView x:Name="tileMapListView"

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml.cs
@@ -79,7 +79,7 @@ namespace DragonQuestinoEditor
 
             if ( tileVM != null && tileVM.Index != _tileIndexCache )
             {
-               tileVM.SetIndex( _tileIndexCache );
+               tileVM.Index = _tileIndexCache;
             }
          }
       }
@@ -92,7 +92,7 @@ namespace DragonQuestinoEditor
 
             if ( mapTileVM != null )
             {
-               mapTileVM.SetIndex( droppedTileVM.Index );
+               mapTileVM.Index = droppedTileVM.Index ;
                mapTileVM.ShouldHighlight = false;
             }
          }

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
@@ -182,7 +182,7 @@ namespace DragonQuestinoEditor
          int offset = _cellY * _tilesPerRow + _cellX;
          var tileViewModel = TileMap[offset];
 
-         if ( tileViewModel.Index == SelectedPaintingIndex)
+         if (tileViewModel.Index == SelectedPaintingIndex)
          {
             // No need to redraw the tile if it's the same
             return;
@@ -226,9 +226,18 @@ namespace DragonQuestinoEditor
          SetZoomLevel( delta );
       }
 
+      protected override void OnMouseEnter( MouseEventArgs e )
+      {
+         base.OnMouseEnter( e );
+
+         // Mousing over the control steals focus so the keyboard events will work
+         Focus();
+      }
+
       protected override void OnMouseLeftButtonDown( MouseButtonEventArgs e )
       {
          base.OnMouseLeftButtonDown( e );
+
          _isLeftButtonDown = true;
 
          switch (_inputMode)

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
@@ -2,14 +2,20 @@
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Media.Imaging;
 using DragonQuestinoEditor.ViewModels;
 
 namespace DragonQuestinoEditor
 {
    internal class MapPanel : FrameworkElement
    {
+      private readonly SolidColorBrush _background = new SolidColorBrush( Color.FromRgb( 64, 64, 64 ) );
+
       private bool _isLeftButtonDown;
       private Point _dragAnchorPoint;
+
+      private WriteableBitmap? _bitmap;
+      private byte[]? _rawBuffer;
 
       private static readonly DependencyProperty OffsetProperty = DependencyProperty.Register(
          nameof( Offset ),
@@ -27,12 +33,58 @@ namespace DragonQuestinoEditor
          nameof( TileMap ),
          typeof( Collection<TileViewModel> ),
          typeof( MapPanel ),
-         new FrameworkPropertyMetadata( null, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsArrange ) );
+         new PropertyMetadata( OnTileMapChanged ) );
+
+      private static void OnTileMapChanged( DependencyObject obj, DependencyPropertyChangedEventArgs e )
+      {
+         if (obj is not MapPanel sender || e.NewValue is not Collection<TileViewModel> tileMap)
+         {
+            return;
+         }
+
+         sender.PrepareBitmap();
+      }
 
       public Collection<TileViewModel> TileMap
       {
          get => (Collection<TileViewModel>)GetValue( TileMapProperty );
          set => SetValue( TileMapProperty, value );
+      }
+
+      public MapPanel()
+      {
+         ClipToBounds = true;
+      }
+
+      private void PrepareBitmap()
+      {
+         const int tilesPerRow = 140;
+         const int tileWidthInPixels = 16;
+         const int tileHeightInPixels = 16;
+         const int bytesPerPixel = 4;
+
+         int width = tilesPerRow * tileWidthInPixels * bytesPerPixel;
+         int height = tilesPerRow * tileHeightInPixels * bytesPerPixel;
+
+         _bitmap = new WriteableBitmap( width, height, 96, 96, PixelFormats.Bgra32, null );
+         _rawBuffer = new byte[width * height];
+
+         for (int i = 0; i < TileMap.Count; i++)
+         {
+            int cellX = i % tilesPerRow;
+            int cellY = i / tilesPerRow;
+
+            int destX = cellX * tileWidthInPixels * bytesPerPixel;
+            int destY = cellY * tileWidthInPixels;
+
+            int tileIndex = TileMap[i].Index;
+            var tile = TileMap[i].TileSet.Tiles[tileIndex];
+
+            tile.DrawToBuffer( _rawBuffer, width, destX, destY );
+         }
+
+         // I don't know why I have to divide by 4 on the width, height
+         _bitmap.WritePixels( new Int32Rect( 0, 0, _bitmap.PixelWidth / 4, _bitmap.PixelHeight / 4 ), _rawBuffer, _bitmap.PixelWidth, 0 );
       }
 
       protected override void OnMouseLeftButtonDown( MouseButtonEventArgs e )
@@ -61,26 +113,13 @@ namespace DragonQuestinoEditor
 
       protected override void OnRender( DrawingContext dc )
       {
-         if (TileMap is null || TileMap.Count == 0)
+         dc.DrawRectangle( _background, null, new Rect( 0, 0, ActualWidth, ActualHeight ) );
+
+         if (_bitmap is not null)
          {
-            return;
-         }
-
-         dc.DrawRectangle( Brushes.DarkSlateGray, null, new Rect( 0, 0, ActualWidth, ActualHeight ) );
-
-         for (int i = 0; i < TileMap.Count; i++)
-         {
-            var tile = TileMap[i];
-
-            int width = (int)tile.Image.Width;
-            int height = (int)tile.Image.Height;
-
-            var offset = Offset;
-
-            int x = (int)offset.X + (i % 140) * width;
-            int y = (int)offset.Y + (i / 140) * height;
-
-            dc.DrawImage( tile.Image, new Rect( x, y, width, height ) );
+            dc.PushTransform( new ScaleTransform( _zoom, _zoom ) );
+            dc.DrawImage( _bitmap, new Rect( Offset.X, Offset.Y, _bitmap.Width, _bitmap.Height ) );
+            dc.Pop();
          }
       }
    }

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
@@ -30,6 +30,8 @@ namespace DragonQuestinoEditor
 
       private bool _isAnimatingZooming;
 
+      private InputMode _inputMode;
+
       private static readonly DependencyProperty ZoomProperty = DependencyProperty.Register(
          nameof( Zoom ),
          typeof( double ),
@@ -91,6 +93,7 @@ namespace DragonQuestinoEditor
       public MapPanel()
       {
          ClipToBounds = true;
+         Focusable = true;
       }
 
       /// <summary>
@@ -155,6 +158,23 @@ namespace DragonQuestinoEditor
          }
       }
 
+      protected override void OnPreviewKeyDown( KeyEventArgs e )
+      {
+         if (e.Key == Key.Space)
+         {
+            _inputMode = InputMode.Pan;
+            Cursor = Cursors.ScrollAll;
+         }
+      }
+
+      protected override void OnPreviewKeyUp( KeyEventArgs e )
+      {
+         base.OnPreviewKeyUp( e );
+
+         _inputMode = InputMode.Draw;
+         Cursor = Cursors.Arrow;
+      }
+
       protected override void OnMouseWheel( MouseWheelEventArgs e )
       {
          base.OnMouseWheel( e );
@@ -167,10 +187,17 @@ namespace DragonQuestinoEditor
       {
          base.OnMouseLeftButtonDown( e );
 
-         _isLeftButtonDown = true;
-         CaptureMouse();
+         switch (_inputMode)
+         {
+            case InputMode.Pan:
+            {
+               _isLeftButtonDown = true;
+               CaptureMouse();
+               _dragAnchorPoint = e.GetPosition( this ) - Offset;
 
-         _dragAnchorPoint = e.GetPosition( this ) - Offset;
+               break;
+            }
+         }
       }
 
       protected override void OnMouseMove( MouseEventArgs e )
@@ -225,7 +252,7 @@ namespace DragonQuestinoEditor
             dc.PushTransform( transform );
             dc.DrawImage( _bitmap, new Rect( 0, 0, _bitmap.Width, _bitmap.Height ) );
 
-            if (TileHighlight != Rect.Empty)
+            if (TileHighlight != Rect.Empty && _inputMode == InputMode.Draw)
             {
                dc.DrawRectangle( _highlight, null, TileHighlight );
             }

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
@@ -93,6 +93,17 @@ namespace DragonQuestinoEditor
          set => SetValue( TileMapProperty, value );
       }
 
+      public static readonly DependencyProperty SelectedPaintingIndexProperty = DependencyProperty.Register(
+         nameof( SelectedPaintingIndex ),
+         typeof( int ),
+         typeof( MapPanel ) );
+
+      public int SelectedPaintingIndex
+      {
+         get => (int)GetValue( SelectedPaintingIndexProperty );
+         set => SetValue( SelectedPaintingIndexProperty, value );
+      }
+
       public MapPanel()
       {
          ClipToBounds = true;
@@ -201,7 +212,7 @@ namespace DragonQuestinoEditor
 
                int offset = _cellY * _tilesPerRow + _cellX;
                var tileViewModel = TileMap[offset];
-               tileViewModel.SetIndex( 1 );
+               tileViewModel.Index = SelectedPaintingIndex;
 
                var byteBuffer = new byte[_defaultTileSize * _defaultTileSize * 4];
                var tileSprite = TileMap[tileViewModel.Index].TileSet.Tiles[tileViewModel.Index];

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.ObjectModel;
 using System.Windows;
+using System.Windows.Input;
 using System.Windows.Media;
 using DragonQuestinoEditor.ViewModels;
 
@@ -7,6 +8,21 @@ namespace DragonQuestinoEditor
 {
    internal class MapPanel : FrameworkElement
    {
+      private bool _isLeftButtonDown;
+      private Point _dragAnchorPoint;
+
+      private static readonly DependencyProperty OffsetProperty = DependencyProperty.Register(
+         nameof( Offset ),
+         typeof( Vector ),
+         typeof( MapPanel ),
+         new FrameworkPropertyMetadata( new Vector( 0, 0 ), FrameworkPropertyMetadataOptions.AffectsRender ) );
+
+      public Vector Offset
+      {
+         get => (Vector)GetValue( OffsetProperty );
+         set => SetValue( OffsetProperty, value );
+      }
+
       public static readonly DependencyProperty TileMapProperty = DependencyProperty.Register(
          nameof( TileMap ),
          typeof( Collection<TileViewModel> ),
@@ -17,6 +33,30 @@ namespace DragonQuestinoEditor
       {
          get => (Collection<TileViewModel>)GetValue( TileMapProperty );
          set => SetValue( TileMapProperty, value );
+      }
+
+      protected override void OnMouseLeftButtonDown( MouseButtonEventArgs e )
+      {
+         base.OnMouseLeftButtonDown( e );
+
+         _isLeftButtonDown = true;
+         _dragAnchorPoint = e.GetPosition( this ) - Offset;
+      }
+
+      protected override void OnMouseMove( MouseEventArgs e )
+      {
+         base.OnMouseMove( e );
+
+         if (_isLeftButtonDown)
+         {
+            Offset = e.GetPosition( this ) - _dragAnchorPoint;
+         }
+      }
+
+      protected override void OnMouseLeftButtonUp( MouseButtonEventArgs e )
+      {
+         base.OnMouseLeftButtonUp( e );
+         _isLeftButtonDown = false;
       }
 
       protected override void OnRender( DrawingContext dc )
@@ -35,8 +75,10 @@ namespace DragonQuestinoEditor
             int width = (int)tile.Image.Width;
             int height = (int)tile.Image.Height;
 
-            int x = (i % 140) * width;
-            int y = (i / 140) * height;
+            var offset = Offset;
+
+            int x = (int)offset.X + (i % 140) * width;
+            int y = (int)offset.Y + (i / 140) * height;
 
             dc.DrawImage( tile.Image, new Rect( x, y, width, height ) );
          }

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
@@ -92,6 +92,8 @@ namespace DragonQuestinoEditor
          base.OnMouseLeftButtonDown( e );
 
          _isLeftButtonDown = true;
+         CaptureMouse();
+
          _dragAnchorPoint = e.GetPosition( this ) - Offset;
       }
 
@@ -108,6 +110,8 @@ namespace DragonQuestinoEditor
       protected override void OnMouseLeftButtonUp( MouseButtonEventArgs e )
       {
          base.OnMouseLeftButtonUp( e );
+         ReleaseMouseCapture();
+
          _isLeftButtonDown = false;
       }
 

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
@@ -30,6 +30,9 @@ namespace DragonQuestinoEditor
 
       private bool _isAnimatingZooming;
 
+      private int _cellX;
+      private int _cellY;
+
       private InputMode _inputMode;
 
       private static readonly DependencyProperty ZoomProperty = DependencyProperty.Register(
@@ -189,6 +192,29 @@ namespace DragonQuestinoEditor
 
          switch (_inputMode)
          {
+            case InputMode.Draw:
+            {
+               if (_bitmap is null)
+               {
+                  return;
+               }
+
+               int offset = _cellY * _tilesPerRow + _cellX;
+               var tileViewModel = TileMap[offset];
+               tileViewModel.SetIndex( 1 );
+
+               var byteBuffer = new byte[_defaultTileSize * _defaultTileSize * 4];
+               var tileSprite = TileMap[tileViewModel.Index].TileSet.Tiles[tileViewModel.Index];
+               tileSprite.DrawToBuffer( byteBuffer, _defaultTileSize * 4, 0, 0 );
+
+               int destX = _cellX * 16;
+               int destY = _cellY * 16;
+
+               _bitmap.WritePixels( new Int32Rect( destX, destY, _defaultTileSize, _defaultTileSize ), byteBuffer, _defaultTileSize * 4, 0 );
+               InvalidateVisual();
+
+               break;
+            }
             case InputMode.Pan:
             {
                _isLeftButtonDown = true;
@@ -215,10 +241,10 @@ namespace DragonQuestinoEditor
          if (mapRect.Contains( mousePos ))
          {
             var tileSize = GetCurrentTileSize();
-            int cellX = (int)((mousePos.X - Offset.X * Zoom) / tileSize.Width);
-            int cellY = (int)((mousePos.Y - Offset.Y * Zoom) / tileSize.Height);
+            _cellX = (int)((mousePos.X - Offset.X * Zoom) / tileSize.Width);
+            _cellY = (int)((mousePos.Y - Offset.Y * Zoom) / tileSize.Height);
 
-            TileHighlight = new Rect( cellX * _defaultTileSize, cellY * _defaultTileSize, _defaultTileSize, _defaultTileSize );
+            TileHighlight = new Rect( _cellX * _defaultTileSize, _cellY * _defaultTileSize, _defaultTileSize, _defaultTileSize );
          }
          else
          {

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.ObjectModel;
+using System.Windows;
+using System.Windows.Media;
+using DragonQuestinoEditor.ViewModels;
+
+namespace DragonQuestinoEditor
+{
+   internal class MapPanel : FrameworkElement
+   {
+      public static readonly DependencyProperty TileMapProperty = DependencyProperty.Register(
+         nameof( TileMap ),
+         typeof( Collection<TileViewModel> ),
+         typeof( MapPanel ),
+         new FrameworkPropertyMetadata( null, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsArrange ) );
+
+      public Collection<TileViewModel> TileMap
+      {
+         get => (Collection<TileViewModel>)GetValue( TileMapProperty );
+         set => SetValue( TileMapProperty, value );
+      }
+
+      protected override void OnRender( DrawingContext dc )
+      {
+         if (TileMap is null || TileMap.Count == 0)
+         {
+            return;
+         }
+
+         dc.DrawRectangle( Brushes.DarkSlateGray, null, new Rect( 0, 0, ActualWidth, ActualHeight ) );
+
+         for (int i = 0; i < TileMap.Count; i++)
+         {
+            var tile = TileMap[i];
+
+            int width = (int)tile.Image.Width;
+            int height = (int)tile.Image.Height;
+
+            int x = (i % 140) * width;
+            int y = (i / 140) * height;
+
+            dc.DrawImage( tile.Image, new Rect( x, y, width, height ) );
+         }
+      }
+   }
+}

--- a/DragonQuestinoEditor/DragonQuestinoEditor/ViewModels/MainWindowViewModel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/ViewModels/MainWindowViewModel.cs
@@ -26,19 +26,20 @@ namespace DragonQuestinoEditor.ViewModels
 
          for ( int i = 0; i < Constants.TileCount; i++ )
          {
-            var image = new BitmapImage();
+            // TODO: Unused?
+            //var image = new BitmapImage();
 
-            using var stream = new MemoryStream();
-            {
-               var encoder = new PngBitmapEncoder();
-               encoder.Frames.Add( BitmapFrame.Create( _tileSet.TileBitmaps[i] ) );
-               encoder.Save( stream );
-               image.BeginInit();
-               image.CacheOption = BitmapCacheOption.OnLoad;
-               image.StreamSource = stream;
-               image.EndInit();
-               image.Freeze();
-            }
+            //using var stream = new MemoryStream();
+            //{
+            //   var encoder = new PngBitmapEncoder();
+            //   encoder.Frames.Add( BitmapFrame.Create( _tileSet.TileBitmaps[i] ) );
+            //   encoder.Save( stream );
+            //   image.BeginInit();
+            //   image.CacheOption = BitmapCacheOption.OnLoad;
+            //   image.StreamSource = stream;
+            //   image.EndInit();
+            //   image.Freeze();
+            //}
 
             TileSelectionViewModels.Add( new( _tileSet, i ) );
          }

--- a/DragonQuestinoEditor/DragonQuestinoEditor/ViewModels/TileViewModel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/ViewModels/TileViewModel.cs
@@ -19,11 +19,18 @@ namespace DragonQuestinoEditor.ViewModels
 
       public TileSet TileSet { get; }
 
-      private int _index;
+      private int _index = -1;
       public int Index
       {
          get => _index;
-         private set => SetProperty( ref _index, value );
+         set
+         {
+            if (SetProperty( ref _index, value ))
+            {
+               Image = TileSet.TileBitmaps[value];
+               IsPassable = _passableIndexes.Contains( value );
+            }
+         }
       }
 
       private BitmapSource? _image;
@@ -50,16 +57,9 @@ namespace DragonQuestinoEditor.ViewModels
       public TileViewModel( TileSet tileSet, int index )
       {
          TileSet = tileSet;
-         SetIndex( index );
+         Index = index;
 
          _isPassable = _passableIndexes.Contains( index );
-      }
-
-      public void SetIndex( int index )
-      {
-         Index = index;
-         Image = TileSet.TileBitmaps[index];
-         IsPassable = _passableIndexes.Contains( index );
       }
    }
 }

--- a/DragonQuestinoEditor/DragonQuestinoEditor/ViewModels/TileViewModel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/ViewModels/TileViewModel.cs
@@ -17,7 +17,7 @@ namespace DragonQuestinoEditor.ViewModels
          13    // bridge
       ];
 
-      private TileSet _tileSet;
+      public TileSet TileSet { get; }
 
       private int _index;
       public int Index
@@ -49,7 +49,7 @@ namespace DragonQuestinoEditor.ViewModels
 
       public TileViewModel( TileSet tileSet, int index )
       {
-         _tileSet = tileSet;
+         TileSet = tileSet;
          SetIndex( index );
 
          _isPassable = _passableIndexes.Contains( index );
@@ -58,7 +58,7 @@ namespace DragonQuestinoEditor.ViewModels
       public void SetIndex( int index )
       {
          Index = index;
-         Image = _tileSet.TileBitmaps[index];
+         Image = TileSet.TileBitmaps[index];
          IsPassable = _passableIndexes.Contains( index );
       }
    }


### PR DESCRIPTION
## Overview

This PR makes large changes to the Editor by altering how tiles are edited. This replaces the ListView that presented the tiles, which was super slow. With ~19k tiles, that's a heavy layout phase and this was the source of the performance problems. This is now fixed, and in so doing, the Editor has changed how it works, hopefully for the better.

The ListView is now replaced by a `MapPanel`, a custom panel I wrote that's specialized to efficiently draw tiles. We don't need the general layout systrnem when it's just a glorified tile map. This binds to the existing tile view model collection and draws a big bitmap to prepare them, and then blits just that single bitmap when needed (much faster).

Other notable changes:

- The "map panel" can be panned by holding `Space` and dragging with the left mouse button. This is a common idiom in lots of editors
- The "map panel" can be zoomed with the mouse wheel. This works kind of weird, since zoom factors aren't linear, but I treat them as such. So clicking the mouse wheel once will zoom in twice as far, but zooming out once is _way_ more aggressive. This can probably be "linearized," but I didn't bother.
  - 🐛 Panning is a little off when zoomed in or out. I couldn't quickly figure out how to account for this so I didn't bother
  - 🐛 Zooming occurs from the origin, not where your mouse is, which would feel _way_ more natural
- The "map panel" allows "drawing" with the left mouse button. This will alter whatever tile you're clicking on so you can properly change the map. The "tile picker" is now a ListBox that has a selected item, so you can think of this more like an art program's palette, and you're choosing the "color" you're drawing with (this replaces drag and dropping the tile). Note that you can also drag across tiles to change many at once

Note that changing the map and then saving _does work_, so this Editor truly edits.

## Next steps

Assuming this is all good:

- Fixing those two bugs above would help the UX a lot
- Add a "tool picker" above the "tile picker," so it begins to flesh out a true tool panel, where you can choose to draw or pan. This carves out a space for additional things, such as line tools, rectangle tools, and whatever else we can think up
- Refactor the `MapPanel` to encapsulate the input mode. Right now there are `switch` statements all over that figure out what to do given the state. I think an `InputController` or something would be good, and switching modes would mean swapping out what kind of input controller it is. This means the `MapPanel` input would just work, and delegate all that logic to OCP-style classes
- Add a command pattern to the `MapPanel`. This means we could support `Undo` / `Redo`, since it would track the alterations
- Add a Line tool that can draw a sequence of tiles with a drag. This would be more accurate than painting it yourself, since it would only draw them once you let go, giving you the ability to fine-tune the line
- Add a Rectangle tool that draws a block of tiles
- Add some kind of "Smart Water" tool that knows how to use the right tiles to create an accurate shoreline around the perimeter of water (which would understand bends/corners, etc.)
- A "flood fill" tool might be kinda fun