### PR TITLE
Better handling of screen buffer allocation

### DIFF
--- a/DragonQuestino/clock.h
+++ b/DragonQuestino/clock.h
@@ -10,6 +10,7 @@
 typedef struct Clock_t
 {
    uint32_t frameStartMicro;
+   uint32_t lagFrameCount;
 
 #if defined( VISUAL_STUDIO_DEV )
    uint32_t absoluteStartMicro;

--- a/DragonQuestino/clock.h
+++ b/DragonQuestino/clock.h
@@ -3,15 +3,9 @@
 
 #include "common.h"
 
-#if defined( VISUAL_STUDIO_DEV )
 #define CLOCK_FPS                 60
 #define CLOCK_FRAME_MICROSECONDS  16666
 #define CLOCK_FRAME_SECONDS       0.01666666f
-#else
-#define CLOCK_FPS                 30
-#define CLOCK_FRAME_MICROSECONDS  33333
-#define CLOCK_FRAME_SECONDS       0.03333333f
-#endif
 
 typedef struct Clock_t
 {

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -267,8 +267,8 @@ internal void Game_DrawStaticSprites( Game_t* game )
       sx = sprite->position.x - game->tileMapViewport.x;
       sy = sprite->position.y - game->tileMapViewport.y;
 
-      if ( Math_RectsIntersect32( sprite->position.x, sprite->position.y, SPRITE_TEXTURE_SIZE, SPRITE_TEXTURE_SIZE,
-                                  game->tileMapViewport.x, game->tileMapViewport.y, game->tileMapViewport.w, game->tileMapViewport.h ) )
+      if ( Math_RectsIntersect32i( sprite->position.x, sprite->position.y, SPRITE_TEXTURE_SIZE, SPRITE_TEXTURE_SIZE,
+                                   game->tileMapViewport.x, game->tileMapViewport.y, game->tileMapViewport.w, game->tileMapViewport.h ) )
       {
          tx = ( sx < 0 ) ? (uint32_t)( -sx ) : 0;
          ty = ( sy < 0 ) ? (uint32_t)( -sy ) : 0;

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -308,7 +308,6 @@ internal void Game_DrawTextureSection( Game_t* game, uint8_t* memory, uint32_t s
    uint8_t* textureBufferPos = memory + ( ty * stride ) + tx;
    uint16_t* screenBufferPos = game->screen.buffer + ( sy * SCREEN_WIDTH ) + sx;
 
-   // MUFFINS: something's wrong in here, figure that out (look at older code?)
    if ( transparency )
    {
       for ( y = 0; y < th; y++ )

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -306,8 +306,9 @@ internal void Game_DrawTextureSection( Game_t* game, uint8_t* memory, uint32_t s
 {
    uint32_t x, y;
    uint8_t* textureBufferPos = memory + ( ty * stride ) + tx;
-   uint16_t* screenBufferPos = game->screen.playAreaBufferPos + ( sy * SCREEN_WIDTH ) + sx;
+   uint16_t* screenBufferPos = game->screen.buffer + ( sy * SCREEN_WIDTH ) + sx;
 
+   // MUFFINS: something's wrong in here, figure that out (look at older code?)
    if ( transparency )
    {
       for ( y = 0; y < th; y++ )

--- a/DragonQuestino/giga_clock.c
+++ b/DragonQuestino/giga_clock.c
@@ -3,6 +3,7 @@
 void Clock_Init( Clock_t* clock )
 {
    clock->frameStartMicro = 0;
+   clock->lagFrameCount = 0;
 }
 
 void Clock_StartFrame( Clock_t* clock )
@@ -30,5 +31,9 @@ void Clock_EndFrame( Clock_t* clock )
       // I'd like to use delayMicroseconds here, but there are some serious
       // issues with precision. regular "delay" works much better, strangely.
       DELAY_MS( ( CLOCK_FRAME_MICROSECONDS - elapsedMicro ) / 1000 );
+   }
+   else
+   {
+      clock->lagFrameCount++;
    }
 }

--- a/DragonQuestino/giga_shield.cpp
+++ b/DragonQuestino/giga_shield.cpp
@@ -23,7 +23,12 @@ void GigaShield::begin()
    _display->begin();
    _buffer = (uint16_t*)ea_malloc( SCREEN_PIXELS * sizeof( uint16_t ) );
    memset( (void*)_buffer, 0, SCREEN_PIXELS * sizeof( uint16_t ) );
-   memset( (void*)( dsi_getActiveFrameBuffer() ), 0, GIGA_SHIELD_WIDTH * GIGA_SHIELD_HEIGHT * sizeof( uint16_t ) );
+   
+   uint16_t* b = (uint16_t*)( dsi_getActiveFrameBuffer() );
+   for ( int i = 0; i < GIGA_SHIELD_PIXELS; i++ )
+   {
+      b[i] = 0x4208; // dark grey-ish
+   }
 
    _refreshThread = new rtos::Thread( osPriorityHigh );
    _refreshThread->start( mbed::callback( this, &GigaShield::refreshThreadWorker ) );
@@ -38,7 +43,7 @@ void GigaShield::refreshThreadWorker()
       uint16_t* shieldBuffer = (uint16_t*)( dsi_getActiveFrameBuffer() );
       shieldBuffer += ( GIGA_SHIELD_WIDTH * ( ( GIGA_SHIELD_HEIGHT - SCREEN_HEIGHT ) / 2 ) ) + ( ( GIGA_SHIELD_WIDTH - SCREEN_WIDTH ) / 2 );
 
-      dsi_lcdDrawImage( (void *)_buffer, (void *)shieldBuffer, SCREEN_WIDTH, SCREEN_HEIGHT, DMA2D_INPUT_RGB565 );
+      dsi_lcdDrawImage( (void*)_buffer, (void*)shieldBuffer, SCREEN_WIDTH, SCREEN_HEIGHT, DMA2D_INPUT_RGB565 );
    }
 }
 

--- a/DragonQuestino/giga_shield.h
+++ b/DragonQuestino/giga_shield.h
@@ -5,6 +5,9 @@
 #include "Adafruit_GFX.h"
 #include "Arduino_H7_Video.h"
 
+#define GIGA_SHIELD_WIDTH     480
+#define GIGA_SHIELD_HEIGHT    800
+
 typedef struct Screen_t Screen_t;
 
 class GigaShield : public Adafruit_GFX {

--- a/DragonQuestino/giga_shield.h
+++ b/DragonQuestino/giga_shield.h
@@ -7,6 +7,7 @@
 
 #define GIGA_SHIELD_WIDTH     480
 #define GIGA_SHIELD_HEIGHT    800
+#define GIGA_SHIELD_PIXELS    384000
 
 typedef struct Screen_t Screen_t;
 

--- a/DragonQuestino/math.c
+++ b/DragonQuestino/math.c
@@ -1,6 +1,6 @@
 #include "math.h"
 
-Bool_t Math_RectsIntersect32( int32_t x1, int32_t y1, int32_t w1, int32_t h1, int32_t x2, int32_t y2, int32_t w2, int32_t h2 )
+Bool_t Math_RectsIntersect32i( int32_t x1, int32_t y1, int32_t w1, int32_t h1, int32_t x2, int32_t y2, int32_t w2, int32_t h2 )
 {
    return ( x1 < ( x2 + w2 ) && ( x1 + w1 ) > x2 && y1 < ( y2 + h2 ) && ( y1 + h1 ) > y2 ) ? True : False;
 }

--- a/DragonQuestino/math.h
+++ b/DragonQuestino/math.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-Bool_t Math_RectsIntersect32( int32_t x1, int32_t y1, int32_t w1, int32_t h1, int32_t x2, int32_t y2, int32_t w2, int32_t h2 );
+Bool_t Math_RectsIntersect32i( int32_t x1, int32_t y1, int32_t w1, int32_t h1, int32_t x2, int32_t y2, int32_t w2, int32_t h2 );
 
 #if defined( __cplusplus )
 }

--- a/DragonQuestino/screen.c
+++ b/DragonQuestino/screen.c
@@ -1,14 +1,8 @@
 #include "screen.h"
 
-void Screen_Init( Screen_t* screen, uint16_t* screenBuffer )
+void Screen_Init( Screen_t* screen, uint16_t* buffer )
 {
-   screen->screenBuffer = screenBuffer;
-   screen->playAreaBufferPos = screenBuffer +
-      (
-         ( ( ( SCREEN_HEIGHT - PLAY_AREA_HEIGHT ) / 2 ) * SCREEN_WIDTH ) +
-         ( ( SCREEN_WIDTH - PLAY_AREA_WIDTH ) / 2 )
-      );
-
+   screen->buffer = buffer;
    Screen_LoadPalette( screen );
 }
 
@@ -30,17 +24,12 @@ Bool_t Screen_GetPaletteIndexForColor( Screen_t* screen, uint16_t color, uint8_t
 
 void Screen_Wipe( Screen_t* screen, uint8_t paletteIndex )
 {
-   uint32_t i, j;
-   uint16_t* bufferPos = screen->playAreaBufferPos;
+   uint32_t i;
+   uint16_t* bufferPos = screen->buffer;
 
-   for ( i = 0; i < PLAY_AREA_HEIGHT; i++ )
+   for ( i = 0; i < SCREEN_PIXELS; i++ )
    {
-      for ( j = 0; j < PLAY_AREA_WIDTH; j++ )
-      {
-         *bufferPos = screen->palette[paletteIndex];
-         bufferPos++;
-      }
-
-      bufferPos += ( SCREEN_WIDTH - PLAY_AREA_WIDTH );
+      *bufferPos = screen->palette[paletteIndex];
+      bufferPos++;
    }
 }

--- a/DragonQuestino/screen.h
+++ b/DragonQuestino/screen.h
@@ -3,12 +3,9 @@
 
 #include "common.h"
 
-#define SCREEN_WIDTH        480
-#define SCREEN_HEIGHT       800
-#define SCREEN_PIXELS       384000
-#define PLAY_AREA_WIDTH      256
-#define PLAY_AREA_HEIGHT     240
-#define PLAY_AREA_PIXELS     61440
+#define SCREEN_WIDTH        256
+#define SCREEN_HEIGHT       240
+#define SCREEN_PIXELS       61440
 
 #define PALETTE_COLORS           256
 
@@ -16,8 +13,7 @@
 
 typedef struct Screen_t
 {
-   uint16_t* screenBuffer;
-   uint16_t* playAreaBufferPos;
+   uint16_t* buffer;
    uint16_t palette[PALETTE_COLORS];
 }
 Screen_t;
@@ -26,7 +22,7 @@ Screen_t;
 extern "C" {
 #endif
 
-void Screen_Init( Screen_t* screen, uint16_t* screenBuffer );
+void Screen_Init( Screen_t* screen, uint16_t* buffer );
 Bool_t Screen_GetPaletteIndexForColor( Screen_t* screen, uint16_t color, uint8_t* paletteIndex );
 void Screen_Wipe( Screen_t* screen, uint8_t paletteIndex );
 

--- a/DragonQuestinoWinDev/DragonQuestinoWinDev/win_clock.c
+++ b/DragonQuestinoWinDev/DragonQuestinoWinDev/win_clock.c
@@ -10,6 +10,7 @@ void Clock_Init( Clock_t* clock )
    clock->frameStartMicro = 0;
    clock->lastFrameMicro = 0;
    clock->frameCount = 0;
+   clock->lagFrameCount = 0;
 }
 
 void Clock_StartFrame( Clock_t* clock )
@@ -48,6 +49,10 @@ void Clock_EndFrame( Clock_t* clock )
    if ( elapsedMicro <= CLOCK_FRAME_MICROSECONDS )
    {
       DELAY_MS( ( CLOCK_FRAME_MICROSECONDS - elapsedMicro ) / 1000 );
+   }
+   else
+   {
+      clock->lagFrameCount++;
    }
 }
 

--- a/DragonQuestinoWinDev/DragonQuestinoWinDev/win_common.h
+++ b/DragonQuestinoWinDev/DragonQuestinoWinDev/win_common.h
@@ -14,7 +14,7 @@
 #include "game.h"
 
 #define STRING_SIZE_DEFAULT         1024
-#define GRAPHICS_SCALE              1.0f
+#define GRAPHICS_SCALE              3.0f
 
 #define VK_NOCLIP                   49    // 1
 #define VK_FASTWALK                 50    // 2

--- a/DragonQuestinoWinDev/DragonQuestinoWinDev/win_pixel_buffer.c
+++ b/DragonQuestinoWinDev/DragonQuestinoWinDev/win_pixel_buffer.c
@@ -7,11 +7,6 @@ void WinPixelBuffer_Init( WinPixelBuffer_t* buffer, uint32_t w, uint32_t h )
    buffer->h = h;
    buffer->memory16 = (uint16_t*)calloc( w * h, sizeof( uint16_t ) );
    buffer->memory32 = (uint32_t*)calloc( w * h, sizeof( uint32_t ) );
-   buffer->playAreaMemoryPos32 = buffer->memory32 +
-      (
-         ( ( ( SCREEN_HEIGHT - PLAY_AREA_HEIGHT ) / 2 ) * SCREEN_WIDTH ) +
-         ( ( SCREEN_WIDTH - PLAY_AREA_WIDTH ) / 2 )
-      );
 }
 
 void WinPixelBuffer_CleanUp( WinPixelBuffer_t* buffer )

--- a/DragonQuestinoWinDev/DragonQuestinoWinDev/win_pixel_buffer.h
+++ b/DragonQuestinoWinDev/DragonQuestinoWinDev/win_pixel_buffer.h
@@ -9,7 +9,6 @@ typedef struct WinPixelBuffer_t
    uint32_t h;
    uint16_t* memory16;
    uint32_t* memory32;
-   uint32_t* playAreaMemoryPos32;
 }
 WinPixelBuffer_t;
 

--- a/DragonQuestinoWinDev/DragonQuestinoWinDev/win_screen.c
+++ b/DragonQuestinoWinDev/DragonQuestinoWinDev/win_screen.c
@@ -21,20 +21,14 @@ internal uint32_t Convert565To32( uint16_t color )
 
 void Screen_RenderBuffer( Screen_t* screen )
 {
-   uint32_t i, j;
-   uint16_t* playAreaBufferPos16 = screen->playAreaBufferPos;
-   uint32_t* playAreaBufferPos32 = g_globals.screenBuffer.playAreaMemoryPos32;
+   uint32_t i;
+   uint16_t* bufferPos16 = screen->buffer;
+   uint32_t* bufferPos32 = g_globals.screenBuffer.memory32;
 
-   for ( i = 0; i < PLAY_AREA_HEIGHT; i++ )
+   for ( i = 0; i < SCREEN_PIXELS; i++ )
    {
-      for ( j = 0; j < PLAY_AREA_WIDTH; j++ )
-      {
-         *playAreaBufferPos32 = Convert565To32( *playAreaBufferPos16 );
-         playAreaBufferPos16++;
-         playAreaBufferPos32++;
-      }
-
-      playAreaBufferPos16 += ( SCREEN_WIDTH - PLAY_AREA_WIDTH );
-      playAreaBufferPos32 += ( SCREEN_WIDTH - PLAY_AREA_WIDTH );
+      *bufferPos32 = Convert565To32( *bufferPos16 );
+      bufferPos16++;
+      bufferPos32++;
    }
 }


### PR DESCRIPTION
## Overview

This is more like it used to be, we only need to allocate memory for the "play area", which is 256x240 rather than the full 480x800. This also means we can do scaling in the Windows the way we were doing it before. I tried to rotate it and scale it 2x on the Giga display shield, but it was SUPER slow and I couldn't figure out how to make it performant. On the other hand, it turns out we can run at 60fps right now without any lag frames, although I'm not sure if that's because our logic and rendering are on separate threads, but I guess we'll see if we can keep that up.