### PR TITLE
Added GameState_t enum for tile map swapping

### DIFF
--- a/DragonQuestino/common.h
+++ b/DragonQuestino/common.h
@@ -19,6 +19,8 @@
 #include <memory.h>
 #include <limits.h>
 
+#include "enums.h"
+
 #define internal static
 #define global static
 #define local_persist static
@@ -49,17 +51,6 @@ DebugFlags_t;
 DebugFlags_t g_debugFlags;
 
 #endif // VISUAL_STUDIO_DEV
-
-typedef enum Direction_t
-{
-   Direction_Left = 0,
-   Direction_Up,
-   Direction_Right,
-   Direction_Down,
-
-   Direction_Count
-}
-Direction_t;
 
 #if defined( __cplusplus )
 extern "C" {

--- a/DragonQuestino/enums.h
+++ b/DragonQuestino/enums.h
@@ -1,0 +1,24 @@
+#if !defined( ENUMS_H )
+#define ENUMS_H
+
+#include "common.h"
+
+typedef enum Direction_t
+{
+   Direction_Left = 0,
+   Direction_Up,
+   Direction_Right,
+   Direction_Down,
+
+   Direction_Count
+}
+Direction_t;
+
+typedef enum GameState_t
+{
+   GameState_Overworld = 0,
+   GameState_TileMapTransition
+}
+GameState_t;
+
+#endif // ENUMS_H

--- a/DragonQuestino/game.h
+++ b/DragonQuestino/game.h
@@ -17,11 +17,13 @@ typedef struct Game_t
    TileMap_t tileMap;
    Clock_t clock;
    Input_t input;
+   GameState_t state;
    Player_t player;
 
    Vector4i32_t tileMapViewport;
 
    Bool_t isSwappingTileMap;
+   TilePortal_t* swapPortal;
    float tileMapSwapSecondsElapsed;
 }
 Game_t;

--- a/DragonQuestinoWinDev/DragonQuestinoWinDev/DragonQuestinoWinDev.vcxproj
+++ b/DragonQuestinoWinDev/DragonQuestinoWinDev/DragonQuestinoWinDev.vcxproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ClInclude Include="..\..\DragonQuestino\clock.h" />
     <ClInclude Include="..\..\DragonQuestino\common.h" />
+    <ClInclude Include="..\..\DragonQuestino\enums.h" />
     <ClInclude Include="..\..\DragonQuestino\game.h" />
     <ClInclude Include="..\..\DragonQuestino\input.h" />
     <ClInclude Include="..\..\DragonQuestino\math.h" />


### PR DESCRIPTION
## Overview

We're gonna need a `GameState_t` eventually anyway, so I figured I'd start here. When the player steps on a portal, rather than load the new tile map right away (which could potentially take some time), we now wipe the screen first, then load the tile map while the swap counter counts down.