### PR TITLE
Bugfix: walk speed calculation

### DIFF
--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -99,6 +99,18 @@ internal void Game_TicTileMapTransition( Game_t* game )
       game->player.sprite.position.y = (float)( ( int32_t )( TILE_SIZE * ( destinationTileIndex / game->tileMap.tilesX ) ) - game->player.spriteOffset.y ) - COLLISION_THETA;
       game->player.tileIndex = destinationTileIndex;
 
+
+#if defined( VISUAL_STUDIO_DEV )
+      if ( g_debugFlags.fastWalk == False )
+      {
+#endif
+
+      game->player.maxVelocity = TileMap_GetWalkSpeedForTile( game->tileMap.tiles[destinationTileIndex] );
+
+#if defined( VISUAL_STUDIO_DEV )
+      }
+#endif
+
       Sprite_SetDirection( &( game->player.sprite ), arrivalDirection );
    }
    else

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -98,18 +98,7 @@ internal void Game_TicTileMapTransition( Game_t* game )
       // the player sprite gets caught on unpassable tiles unless we use COLLISION_THETA here, but for some reason the x-axis has no problems
       game->player.sprite.position.y = (float)( ( int32_t )( TILE_SIZE * ( destinationTileIndex / game->tileMap.tilesX ) ) - game->player.spriteOffset.y ) - COLLISION_THETA;
       game->player.tileIndex = destinationTileIndex;
-
-
-#if defined( VISUAL_STUDIO_DEV )
-      if ( g_debugFlags.fastWalk == False )
-      {
-#endif
-
       game->player.maxVelocity = TileMap_GetWalkSpeedForTile( game->tileMap.tiles[destinationTileIndex] );
-
-#if defined( VISUAL_STUDIO_DEV )
-      }
-#endif
 
       Sprite_SetDirection( &( game->player.sprite ), arrivalDirection );
    }
@@ -130,17 +119,7 @@ void Game_PlayerSteppedOnTile( Game_t* game, uint32_t tileIndex )
    TilePortal_t* portal;
    uint8_t wipePaletteIndex;
 
-#if defined( VISUAL_STUDIO_DEV )
-   if ( g_debugFlags.fastWalk == False )
-   {
-#endif
-
    game->player.maxVelocity = TileMap_GetWalkSpeedForTile( game->tileMap.tiles[tileIndex] );
-
-#if defined( VISUAL_STUDIO_DEV )
-   }
-#endif
-
    game->player.tileIndex = tileIndex;
    portal = TileMap_GetPortalForTileIndex( &( game->tileMap ), tileIndex );
 

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -98,7 +98,7 @@ internal void Game_TicTileMapTransition( Game_t* game )
       // the player sprite gets caught on unpassable tiles unless we use COLLISION_THETA here, but for some reason the x-axis has no problems
       game->player.sprite.position.y = (float)( ( int32_t )( TILE_SIZE * ( destinationTileIndex / game->tileMap.tilesX ) ) - game->player.spriteOffset.y ) - COLLISION_THETA;
       game->player.tileIndex = destinationTileIndex;
-      game->player.maxVelocity = TileMap_GetWalkSpeedForTile( game->tileMap.tiles[destinationTileIndex] );
+      game->player.maxVelocity = TileMap_GetWalkSpeedForTileIndex( &( game->tileMap ), destinationTileIndex );
 
       Sprite_SetDirection( &( game->player.sprite ), arrivalDirection );
    }
@@ -119,7 +119,7 @@ void Game_PlayerSteppedOnTile( Game_t* game, uint32_t tileIndex )
    TilePortal_t* portal;
    uint8_t wipePaletteIndex;
 
-   game->player.maxVelocity = TileMap_GetWalkSpeedForTile( game->tileMap.tiles[tileIndex] );
+   game->player.maxVelocity = TileMap_GetWalkSpeedForTileIndex( &( game->tileMap ), tileIndex );
    game->player.tileIndex = tileIndex;
    portal = TileMap_GetPortalForTileIndex( &( game->tileMap ), tileIndex );
 

--- a/DragonQuestino/tile_map.c
+++ b/DragonQuestino/tile_map.c
@@ -1,7 +1,8 @@
 #include "tile_map.h"
 
-float TileMap_GetWalkSpeedForTile( uint16_t tile )
+float TileMap_GetWalkSpeedForTileIndex( TileMap_t* tileMap, uint32_t tileIndex )
 {
+   uint16_t tile = tileMap->tiles[( ( tileIndex / tileMap->tilesX ) * TILE_COUNT_X ) + ( tileIndex % tileMap->tilesX )];
    uint16_t walkSpeed = GET_TILEWALKSPEED( tile );
 
 #if defined( VISUAL_STUDIO_DEV )

--- a/DragonQuestino/tile_map.c
+++ b/DragonQuestino/tile_map.c
@@ -4,6 +4,15 @@ float TileMap_GetWalkSpeedForTile( uint16_t tile )
 {
    uint16_t walkSpeed = GET_TILEWALKSPEED( tile );
 
+#if defined( VISUAL_STUDIO_DEV )
+
+   if ( g_debugFlags.fastWalk )
+   {
+      return TILE_WALKSPEED_FAST;
+   }
+
+#endif
+
    switch ( walkSpeed )
    {
       case 0: return TILE_WALKSPEED_NORMAL;

--- a/DragonQuestino/tile_map.h
+++ b/DragonQuestino/tile_map.h
@@ -81,7 +81,7 @@ TileMap_t;
 extern "C" {
 #endif
 
-float TileMap_GetWalkSpeedForTile( uint16_t tile );
+float TileMap_GetWalkSpeedForTileIndex( TileMap_t* tileMap, uint32_t tileIndex );
 TilePortal_t* TileMap_GetPortalForTileIndex( TileMap_t* tileMap, uint32_t index );
 
 // game_data.c

--- a/DragonQuestinoWinDev/DragonQuestinoWinDev/win_main.c
+++ b/DragonQuestinoWinDev/DragonQuestinoWinDev/win_main.c
@@ -361,7 +361,6 @@ internal void ToggleFastWalk()
    }
    else
    {
-      uint16_t tile = g_globals.game.tileMap.tiles[g_globals.game.player.tileIndex];
-      g_globals.game.player.maxVelocity = TileMap_GetWalkSpeedForTile( tile );
+      g_globals.game.player.maxVelocity = TileMap_GetWalkSpeedForTileIndex( &( g_globals.game.tileMap ), g_globals.game.player.tileIndex );
    }
 }


### PR DESCRIPTION
Addressed Issue: #18 

## Overview

This was an interesting find, not only was I not updating the player's walk speed when switching tile maps, but I was also not taking into account the tile map's size. This should fix both issues.