### PR TITLE
All of Alex's Editor changes, rebased on my updates

### DIFF
--- a/DragonQuestinoEditor/DragonQuestinoEditor/FileOps/SaveDataFileOps.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/FileOps/SaveDataFileOps.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.ObjectModel;
 using System.IO;
 using System.Text.Json;
+using DragonQuestinoEditor.Graphics;
 using DragonQuestinoEditor.ViewModels;
 
 namespace DragonQuestinoEditor.FileOps
@@ -13,7 +14,7 @@ namespace DragonQuestinoEditor.FileOps
          File.WriteAllText( filePath, JsonSerializer.Serialize( saveData ) );
       }
 
-      public static bool LoadData( string filePath, ObservableCollection<TileMapViewModel> tileMaps )
+      public static bool LoadData( string filePath, TileSet tileSet, ObservableCollection<TileMapViewModel> tileMaps )
       {
          var contents = File.ReadAllText( filePath );
          var saveData = JsonSerializer.Deserialize<SaveData>( contents );
@@ -25,7 +26,7 @@ namespace DragonQuestinoEditor.FileOps
 
          foreach ( var tileMapSaveData in saveData.TileMaps )
          {
-            tileMaps.Add( new( tileMapSaveData ) );
+            tileMaps.Add( new( tileSet, tileMapSaveData ) );
          }
 
          return true;

--- a/DragonQuestinoEditor/DragonQuestinoEditor/Graphics/Sprite.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/Graphics/Sprite.cs
@@ -57,6 +57,22 @@ namespace DragonQuestinoEditor.Graphics
          return _pixels[x, y];
       }
 
+      public Sprite Extract( int x, int y, int width, int height )
+      {
+         var newSprite = new Sprite( width, height );
+
+         for (int row = 0; row < height; row++)
+         {
+            for (int col = 0; col < width; col++)
+            {
+               var srcPixel = GetPixel( col + x, row + y );
+               newSprite.SetPixel( col, row, srcPixel );
+            }
+         }
+
+         return newSprite;
+      }
+
       private byte[] ConvertToLinearBuffer()
       {
          var linearPixelBuffer = new byte[_pixels.Length * 4];

--- a/DragonQuestinoEditor/DragonQuestinoEditor/Graphics/Sprite.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/Graphics/Sprite.cs
@@ -5,7 +5,7 @@ using System.Windows.Media.Imaging;
 
 namespace DragonQuestinoEditor.Graphics
 {
-   internal class Sprite
+   public class Sprite
    {
       private readonly Color[,] _pixels;
 

--- a/DragonQuestinoEditor/DragonQuestinoEditor/Graphics/Sprite.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/Graphics/Sprite.cs
@@ -1,0 +1,93 @@
+﻿using System.IO;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace DragonQuestinoEditor.Graphics
+{
+   internal class Sprite
+   {
+      private readonly Color[,] _pixels;
+
+      public int Width { get; }
+      public int Height { get; }
+
+      public Sprite( int width, int height )
+      {
+         Width = width;
+         Height = height;
+
+         _pixels = new Color[width, height];
+      }
+
+      public static Sprite LoadFromFile( string path )
+      {
+         using var fileStream = new FileStream( path, FileMode.Open, FileAccess.Read );
+         var decoder = new PngBitmapDecoder( fileStream, BitmapCreateOptions.PreservePixelFormat, BitmapCacheOption.Default );
+         var bitmapFrame = decoder.Frames[0];
+
+         int stride = bitmapFrame.PixelWidth * bitmapFrame.Format.BitsPerPixel / 8;
+
+         var data = new byte[stride * bitmapFrame.PixelHeight];
+         bitmapFrame.CopyPixels( data, stride, 0 );
+
+         var sprite = new Sprite( bitmapFrame.PixelWidth, bitmapFrame.PixelHeight );
+         int sourceOffset = 0;
+
+         for (int y = 0; y < bitmapFrame.PixelHeight; y++)
+         {
+            for (int x = 0; x < bitmapFrame.PixelWidth; x++)
+            {
+               int pixelIndex = data[sourceOffset++];
+               var color = bitmapFrame.Palette.Colors[pixelIndex];
+               sprite.SetPixel( x, y, color );
+            }
+         }
+
+         return sprite;
+      }
+
+      public void SetPixel( int x, int y, Color color )
+      {
+         _pixels[x, y] = color;
+      }
+
+      public Color GetPixel( int x, int y )
+      {
+         return _pixels[x, y];
+      }
+
+      private byte[] ConvertToLinearBuffer()
+      {
+         var linearPixelBuffer = new byte[_pixels.Length * 4];
+         int offset = 0;
+
+         for (int y = 0; y < Height; y++)
+         {
+            for (int x = 0; x < Width; x++)
+            {
+               linearPixelBuffer[offset++] = _pixels[x, y].B;
+               linearPixelBuffer[offset++] = _pixels[x, y].G;
+               linearPixelBuffer[offset++] = _pixels[x, y].R;
+               linearPixelBuffer[offset++] = _pixels[x, y].A;
+            }
+         }
+
+         return linearPixelBuffer;
+      }
+
+      public void SaveAsPng( string path )
+      {
+         var linearPixelBuffer = ConvertToLinearBuffer();
+
+         var writableBitmap = new WriteableBitmap( Width, Height, 96, 96, PixelFormats.Bgra32, null );
+         writableBitmap.WritePixels( new Int32Rect( 0, 0, Width, Height ), linearPixelBuffer, Width * 4, 0 );
+
+         using var fileStream = new FileStream( path, FileMode.Create, FileAccess.Write );
+
+         var encoder = new PngBitmapEncoder();
+         encoder.Frames.Add( BitmapFrame.Create( writableBitmap ) );
+         encoder.Save( fileStream );
+      }
+   }
+}

--- a/DragonQuestinoEditor/DragonQuestinoEditor/Graphics/Sprite.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/Graphics/Sprite.cs
@@ -73,6 +73,26 @@ namespace DragonQuestinoEditor.Graphics
          return newSprite;
       }
 
+      public void DrawToBuffer( byte[] buffer, int bufferWidth, int x, int y )
+      {
+         for (int row = 0; row < Height; row++)
+         {
+            for (int col = 0; col < Width; col++)
+            {
+               var pixel = GetPixel( col, row );
+
+               int destX = x + col * 4;
+               int destY = y + row;
+               int offset = destY * bufferWidth + destX;
+
+               buffer[offset + 0] = pixel.B;
+               buffer[offset + 1] = pixel.G;
+               buffer[offset + 2] = pixel.R;
+               buffer[offset + 3] = pixel.A;
+            }
+         }
+      }
+
       private byte[] ConvertToLinearBuffer()
       {
          var linearPixelBuffer = new byte[_pixels.Length * 4];

--- a/DragonQuestinoEditor/DragonQuestinoEditor/Graphics/TileSet.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/Graphics/TileSet.cs
@@ -9,12 +9,12 @@ namespace DragonQuestinoEditor.Graphics
    {
       private readonly List<WriteableBitmap> _tileBitmaps = new( Constants.TileTextureCount );
       private readonly Palette _palette;
-      private readonly Sprite[] _tiles = new Sprite[Constants.TileCount];
+      private readonly Sprite[] _tileTextures = new Sprite[Constants.TileTextureCount];
 
       public List<List<int>> TilePaletteIndexes = new ( Constants.TileTextureCount );
 
       public List<WriteableBitmap> TileBitmaps => _tileBitmaps;
-      public Sprite[] Tiles => _tiles;
+      public Sprite[] TileTextures => _tileTextures;
 
       public TileSet( string imagePath, Palette palette )
       {
@@ -33,13 +33,13 @@ namespace DragonQuestinoEditor.Graphics
          var tileSheet = Sprite.LoadFromFile( imagePath );
          int tileCount = tileSheet.Width / Constants.TileSize;
 
-         for (int tileIndex = 0; tileIndex < tileCount; tileIndex++)
+         for (int textureIndex = 0; textureIndex < tileCount; textureIndex++)
          {
-            int srcX = tileIndex * Constants.TileSize;
+            int srcX = textureIndex * Constants.TileSize;
             int srcY = 0;
 
             var tileSprite = tileSheet.Extract( srcX, srcY, Constants.TileSize, Constants.TileSize );
-            _tiles[tileIndex] = tileSprite;
+            _tileTextures[textureIndex] = tileSprite;
          }
       }
 

--- a/DragonQuestinoEditor/DragonQuestinoEditor/Graphics/TileSet.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/Graphics/TileSet.cs
@@ -9,10 +9,12 @@ namespace DragonQuestinoEditor.Graphics
    {
       private readonly List<WriteableBitmap> _tileBitmaps = new( Constants.TileTextureCount );
       private readonly Palette _palette;
+      private readonly Sprite[] _tiles = new Sprite[Constants.TileCount];
 
       public List<List<int>> TilePaletteIndexes = new ( Constants.TileTextureCount );
 
       public List<WriteableBitmap> TileBitmaps => _tileBitmaps;
+      public Sprite[] Tiles => _tiles;
 
       public TileSet( string imagePath, Palette palette )
       {
@@ -21,9 +23,24 @@ namespace DragonQuestinoEditor.Graphics
          var textFileStream = new FileStream( imagePath, FileMode.Open, FileAccess.Read, FileShare.Read );
          var textDecoder = new PngBitmapDecoder( textFileStream, BitmapCreateOptions.PreservePixelFormat, BitmapCacheOption.Default );
          var bitmapSource = textDecoder.Frames[0];
+
          BitmapUtils.CheckTileSetBitmapFormat( bitmapSource );
          ReadTileBitmaps( bitmapSource );
          UpdatePalette();
+
+         // Extract the tiles as sprites
+
+         var tileSheet = Sprite.LoadFromFile( imagePath );
+         int tileCount = tileSheet.Width / Constants.TileSize;
+
+         for (int tileIndex = 0; tileIndex < tileCount; tileIndex++)
+         {
+            int srcX = tileIndex * Constants.TileSize;
+            int srcY = 0;
+
+            var tileSprite = tileSheet.Extract( srcX, srcY, Constants.TileSize, Constants.TileSize );
+            _tiles[tileIndex] = tileSprite;
+         }
       }
 
       private void ReadTileBitmaps( BitmapSource bitmapSource )

--- a/DragonQuestinoEditor/DragonQuestinoEditor/InputMode.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/InputMode.cs
@@ -1,0 +1,8 @@
+﻿namespace DragonQuestinoEditor
+{
+   internal enum InputMode
+   {
+      Draw,
+      Pan
+   }
+}

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
@@ -16,7 +16,8 @@
                 TargetType="{x:Type ListViewItem}">
             <Setter Property="Background"
                     Value="Transparent" />
-            <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+            <Setter Property="FocusVisualStyle"
+                    Value="{x:Null}" />
             <Setter Property="Template">
                <Setter.Value>
                   <ControlTemplate TargetType="{x:Type ListViewItem}">

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
@@ -12,14 +12,12 @@
 		ResizeMode="NoResize"
         FocusManager.FocusedElement="{Binding ElementName=MapPanel}">
    <Window.Resources>
-      <ResourceDictionary>
-         <DragonQuestinoEditorConverters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"
-                                                                   TrueValue="Visible"
-                                                                   FalseValue="Collapsed" />
-         <DragonQuestinoEditorConverters:BoolToVisibilityConverter x:Key="InverseBoolToVisibilityConverter"
-                                                                   TrueValue="Collapsed"
-                                                                   FalseValue="Visible" />
-      </ResourceDictionary>
+      <DragonQuestinoEditorConverters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"
+                                                                  TrueValue="Visible"
+                                                                  FalseValue="Collapsed" />
+      <DragonQuestinoEditorConverters:BoolToVisibilityConverter x:Key="InverseBoolToVisibilityConverter"
+                                                                  TrueValue="Collapsed"
+                                                                  FalseValue="Visible" />
    </Window.Resources>
    
    <!-- Window Contents -->
@@ -51,37 +49,6 @@
                <local:MapPanel x:Name="MapPanel"
                                TileMap="{Binding SelectedTileMap.Tiles}"
                                SelectedPaintingIndex="{Binding SelectedItem.TextureIndex, ElementName=tileSelectionListView, Mode=TwoWay}" />
-               
-               <!--<ListView ItemsSource="{Binding SelectedTileMap.Tiles}"
-                         VerticalAlignment="Top"
-                         HorizontalAlignment="Left"
-                         Width="{Binding TileMapTextureListViewWidth}"
-                         Height="{Binding TileMapTextureListViewHeight}"
-                         ItemContainerStyle="{StaticResource TileListItemContainerStyle}"
-                         AllowDrop="True"
-                         PreviewMouseDown="TileMapTextureListView_OnPreviewMouseDown"
-                         MouseMove="TileMapTextureListView_OnMouseMove"
-                         Drop="TileMapTextureListView_OnDrop">
-                  <ItemsControl.ItemsPanel>
-                     <ItemsPanelTemplate>
-                        <UniformGrid Columns="{Binding SelectedTileMap.TilesX}"/>
-                     </ItemsPanelTemplate>
-                  </ItemsControl.ItemsPanel>
-                  <ListView.ItemTemplate>
-                     <DataTemplate>
-                        <Grid DragEnter="TileMapTextureListViewImage_OnDragEnter"
-                              DragLeave="TileMapTextureListViewImage_OnDragLeave">
-                           <Image Source="{Binding Image}"
-                                  Width="32"
-                                  Height="32"/>
-                           <Rectangle Width="32"
-                                      Height="32"
-                                      Fill="#660000FF"
-                                      Visibility="{Binding IsDraggingTextureOver, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                        </Grid>
-                     </DataTemplate>
-                  </ListView.ItemTemplate>
-               </ListView>-->
 
                <!-- Tile Map Texture Editor Control Panel -->
                <StackPanel Orientation="Vertical">
@@ -122,37 +89,6 @@
 
                   <local:MapPanel TileMap="{Binding TileMapViewModels}"
                                   SelectedPaintingIndex="{Binding SelectedItem.TextureIndex, ElementName=tileSelectionListView, Mode=TwoWay}" />
-                  
-                  <!--<ListView ItemsSource="{Binding SelectedTileMap.Tiles}"
-                            VerticalAlignment="Top"
-                            HorizontalAlignment="Left"
-                            Width="{Binding TileMapPortalListViewWidth}"
-                            Height="{Binding TileMapPortalListViewHeight}"
-                            ItemContainerStyle="{StaticResource TileListItemContainerStyle}"
-                            SelectionChanged="TileMapPortalSourceListView_OnSelectionChanged">
-                     <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                           <UniformGrid Columns="{Binding SelectedTileMap.TilesX}"/>
-                        </ItemsPanelTemplate>
-                     </ItemsControl.ItemsPanel>
-                     <ListView.ItemTemplate>
-                        <DataTemplate>
-                           <Grid>
-                              <Image Source="{Binding Image}"
-                                     Width="32"
-                                     Height="32" />
-                              <Rectangle Width="32"
-                                         Height="32"
-                                         Fill="#66FF00FF"
-                                         Visibility="{Binding HasPortal, Converter={StaticResource BoolToVisibilityConverter}}" />
-                              <Rectangle Width="32"
-                                         Height="32"
-                                         Fill="#660000FF"
-                                         Visibility="{Binding IsSelected, Converter={StaticResource BoolToVisibilityConverter}}" />
-                           </Grid>
-                        </DataTemplate>
-                     </ListView.ItemTemplate>
-                  </ListView>-->
 
                </StackPanel> <!-- Source Portal Tiles -->
                   

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
@@ -9,15 +9,15 @@
         Title="Dragon Questino Editor"
         Height="848"
         Width="1320"
-		ResizeMode="NoResize"
+		  ResizeMode="NoResize"
         FocusManager.FocusedElement="{Binding ElementName=MapPanel}">
    <Window.Resources>
       <DragonQuestinoEditorConverters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"
-                                                                  TrueValue="Visible"
-                                                                  FalseValue="Collapsed" />
+                                                                TrueValue="Visible"
+                                                                FalseValue="Collapsed" />
       <DragonQuestinoEditorConverters:BoolToVisibilityConverter x:Key="InverseBoolToVisibilityConverter"
-                                                                  TrueValue="Collapsed"
-                                                                  FalseValue="Visible" />
+                                                                TrueValue="Collapsed"
+                                                                FalseValue="Visible" />
    </Window.Resources>
    
    <!-- Window Contents -->
@@ -42,23 +42,24 @@
       <TabControl>
 
          <!-- Tile Map Texture Editor -->
-         <TabItem Header="Textures">
+         <TabItem Header="Textures"
+                  IsSelected="True">
             <StackPanel Orientation="Horizontal">
 
                <!-- Tile Map Texture Editor Tiles -->
                <local:MapPanel x:Name="MapPanel"
                                TileMap="{Binding SelectedTileMap.Tiles}"
-                               SelectedPaintingIndex="{Binding SelectedItem.TextureIndex, ElementName=tileSelectionListView, Mode=TwoWay}" />
+                               SelectedTextureIndex="{Binding SelectedItem.TextureIndex, ElementName=tileSelectionListView, Mode=TwoWay}" />
 
                <!-- Tile Map Texture Editor Control Panel -->
                <StackPanel Orientation="Vertical">
 
                   <!-- Tile Map Texture Editor Texture Picker -->
                   <ListBox x:Name="tileSelectionListView"
-                           ItemsSource="{Binding TileSelectionViewModels}"
+                           ItemsSource="{Binding TileTextureViewModels}"
                            VerticalAlignment="Top"
                            HorizontalAlignment="Left"
-                           MouseMove="TileSelectionListView_OnMouseMove">
+                           MouseMove="TileTextureListView_OnMouseMove">
                      <ListBox.ItemsPanel>
                         <ItemsPanelTemplate>
                            <UniformGrid Columns="4" />
@@ -80,15 +81,14 @@
          </TabItem> <!-- Tile Map Texture Editor -->
 
          <!-- Tile Map Portal Editor -->
-         <TabItem Header="Portals"
-                  IsSelected="True">
+         <TabItem Header="Portals">
             <StackPanel Orientation="Horizontal">
                   
                <!-- Source Portal Tiles -->
                <StackPanel Orientation="Vertical">
 
-                  <local:MapPanel TileMap="{Binding TileMapViewModels}"
-                                  SelectedPaintingIndex="{Binding SelectedItem.TextureIndex, ElementName=tileSelectionListView, Mode=TwoWay}" />
+                  <local:MapPanel TileMap="{Binding SelectedTileMap.Tiles}"
+                                  SelectedTextureIndex="{Binding SelectedItem.TextureIndex, ElementName=tileSelectionListView, Mode=TwoWay}" />
 
                </StackPanel> <!-- Source Portal Tiles -->
                   
@@ -118,32 +118,10 @@
                <!-- Destination Portal Tiles -->
                <StackPanel Orientation="Vertical"
                            Visibility="{Binding PortalIsSelected, Converter={StaticResource BoolToVisibilityConverter}}">
-                  <ListView ItemsSource="{Binding PortalDestinationTileMap.Tiles}"
-                            VerticalAlignment="Top"
-                            HorizontalAlignment="Left"
-                            Width="{Binding TileMapPortalDestinationListViewWidth}"
-                            Height="{Binding TileMapPortalDestinationListViewHeight}"
-                            ItemContainerStyle="{StaticResource TileListItemContainerStyle}"
-                            SelectionChanged="TileMapPortalDestinationListView_OnSelectionChanged">
-                     <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                           <UniformGrid Columns="{Binding PortalDestinationTileMap.TilesX}" />
-                        </ItemsPanelTemplate>
-                     </ItemsControl.ItemsPanel>
-                     <ListView.ItemTemplate>
-                        <DataTemplate>
-                           <Grid>
-                              <Image Source="{Binding Image}"
-                                     Width="32"
-                                     Height="32" />
-                              <Rectangle Width="32"
-                                         Height="32"
-                                         Fill="#66FF00FF"
-                                         Visibility="{Binding IsPortalDestination, Converter={StaticResource BoolToVisibilityConverter}}" />
-                           </Grid>
-                        </DataTemplate>
-                     </ListView.ItemTemplate>
-                  </ListView>
+
+                  <local:MapPanel TileMap="{Binding PortalDestinationTileMap.Tiles}"
+                                  SelectedTextureIndex="{Binding SelectedItem.TextureIndex, ElementName=tileSelectionListView, Mode=TwoWay}" />
+
                </StackPanel>
 
             </StackPanel>

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
@@ -13,20 +13,6 @@
         FocusManager.FocusedElement="{Binding ElementName=MapPanel}">
    <Window.Resources>
       <ResourceDictionary>
-         <Style x:Key="TileListItemContainerStyle"
-                TargetType="{x:Type ListViewItem}">
-            <Setter Property="Background"
-                    Value="Transparent" />
-            <Setter Property="FocusVisualStyle"
-                    Value="{x:Null}" />
-            <Setter Property="Template">
-               <Setter.Value>
-                  <ControlTemplate TargetType="{x:Type ListViewItem}">
-                     <ContentPresenter />
-                  </ControlTemplate>
-               </Setter.Value>
-            </Setter>
-         </Style>
          <DragonQuestinoEditorConverters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"
                                                                    TrueValue="Visible"
                                                                    FalseValue="Collapsed" />
@@ -100,25 +86,41 @@
                <StackPanel Orientation="Vertical">
 
                   <!-- Tile Map Texture Editor Texture Picker -->
-                  <ListView x:Name="tileTextureListView"
-                            ItemsSource="{Binding TileTextureViewModels}"
-                            VerticalAlignment="Top"
-                            HorizontalAlignment="Left"
-                            ItemContainerStyle="{StaticResource TileListItemContainerStyle}"
-                            MouseMove="TileTextureListView_OnMouseMove">
-                     <ItemsControl.ItemsPanel>
+                  <ListBox x:Name="tileSelectionListView"
+                           ItemsSource="{Binding TileSelectionViewModels}"
+                           VerticalAlignment="Top"
+                           HorizontalAlignment="Left"
+                           MouseMove="TileSelectionListView_OnMouseMove">
+                     <ListBox.ItemsPanel>
                         <ItemsPanelTemplate>
                            <UniformGrid Columns="4" />
                         </ItemsPanelTemplate>
-                     </ItemsControl.ItemsPanel>
-                     <ListView.ItemTemplate>
+                     </ListBox.ItemsPanel>
+
+                     <ListBox.ItemTemplate>
                         <DataTemplate>
                            <Image Source="{Binding Image}"
                                   Width="32"
                                   Height="32" />
                         </DataTemplate>
-                     </ListView.ItemTemplate>
-                  </ListView>
+                     </ListBox.ItemTemplate>
+
+                     <ListBox.ItemContainerStyle>
+                        <Style TargetType="{x:Type ListBoxItem}">
+                           <Setter Property="Background"
+                                   Value="Transparent" />
+                           <Setter Property="FocusVisualStyle"
+                                   Value="{x:Null}" />
+                           <Setter Property="Template">
+                              <Setter.Value>
+                                 <ControlTemplate TargetType="{x:Type ListBoxItem}">
+                                    <ContentPresenter />
+                                 </ControlTemplate>
+                              </Setter.Value>
+                           </Setter>
+                        </Style>
+                     </ListBox.ItemContainerStyle>
+                  </ListBox>
 
                </StackPanel> <!-- Tile Map Texture Editor Control Panel -->
                   

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
@@ -34,43 +34,108 @@
                                                                    FalseValue="Visible" />
       </ResourceDictionary>
    </Window.Resources>
-   <Grid>
-      <!-- Window Contents -->
-      <StackPanel Orientation="Vertical">
+   
+   <!-- Window Contents -->
+   <StackPanel Orientation="Vertical">
 
-         <!-- Tile Map Operations -->
-         <StackPanel Orientation="Horizontal">
-            <ComboBox ItemsSource="{Binding TileMaps}"
-                      SelectedItem="{Binding SelectedTileMap}"
-                      DisplayMemberPath="Name"/>
-            <Button Content="New Tile Map"
-                    Command="{Binding NewTileMapCommand, Mode=OneTime}"/>
-            <Button Content="Delete Tile Map"
-                    Command="{Binding DeleteTileMapCommand, Mode=OneTime}"/>
-            <Button Content="Save Tile Maps"
-                    Command="{Binding SaveTileMapsCommand, Mode=OneTime}"/>
-            <Button Content="Write Game Data"
-                    Command="{Binding WriteGameDataCommand, Mode=OneTime}"/>
-         </StackPanel>
+      <!-- Tile Map Operations -->
+      <StackPanel Orientation="Horizontal">
+         <ComboBox ItemsSource="{Binding TileMaps}"
+                   SelectedItem="{Binding SelectedTileMap}"
+                   DisplayMemberPath="Name" />
+         <Button Content="New Tile Map"
+                 Command="{Binding NewTileMapCommand, Mode=OneTime}" />
+         <Button Content="Delete Tile Map"
+                 Command="{Binding DeleteTileMapCommand, Mode=OneTime}" />
+         <Button Content="Save Tile Maps"
+                 Command="{Binding SaveTileMapsCommand, Mode=OneTime}" />
+         <Button Content="Write Game Data"
+                 Command="{Binding WriteGameDataCommand, Mode=OneTime}" />
+      </StackPanel>
 
-         <!-- Tile Map Tabs -->
-         <TabControl>
+      <!-- Tile Map Tabs -->
+      <TabControl>
 
-            <!-- Tile Map Texture Editor -->
-            <TabItem Header="Textures">
-               <StackPanel Orientation="Horizontal">
+         <!-- Tile Map Texture Editor -->
+         <TabItem Header="Textures">
+            <StackPanel Orientation="Horizontal">
 
-                  <!-- Tile Map Texture Editor Tiles -->
+               <!-- Tile Map Texture Editor Tiles -->
+               <ListView ItemsSource="{Binding SelectedTileMap.Tiles}"
+                         VerticalAlignment="Top"
+                         HorizontalAlignment="Left"
+                         Width="{Binding TileMapTextureListViewWidth}"
+                         Height="{Binding TileMapTextureListViewHeight}"
+                         ItemContainerStyle="{StaticResource TileListItemContainerStyle}"
+                         AllowDrop="True"
+                         PreviewMouseDown="TileMapTextureListView_OnPreviewMouseDown"
+                         MouseMove="TileMapTextureListView_OnMouseMove"
+                         Drop="TileMapTextureListView_OnDrop">
+                  <ItemsControl.ItemsPanel>
+                     <ItemsPanelTemplate>
+                        <UniformGrid Columns="{Binding SelectedTileMap.TilesX}"/>
+                     </ItemsPanelTemplate>
+                  </ItemsControl.ItemsPanel>
+                  <ListView.ItemTemplate>
+                     <DataTemplate>
+                        <Grid DragEnter="TileMapTextureListViewImage_OnDragEnter"
+                              DragLeave="TileMapTextureListViewImage_OnDragLeave">
+                           <Image Source="{Binding Image}"
+                                  Width="32"
+                                  Height="32"/>
+                           <Rectangle Width="32"
+                                      Height="32"
+                                      Fill="#660000FF"
+                                      Visibility="{Binding IsDraggingTextureOver, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                        </Grid>
+                     </DataTemplate>
+                  </ListView.ItemTemplate>
+               </ListView>
+
+               <!-- Tile Map Texture Editor Control Panel -->
+               <StackPanel Orientation="Vertical">
+
+                  <!-- Tile Map Texture Editor Texture Picker -->
+                  <ListView x:Name="tileTextureListView"
+                            ItemsSource="{Binding TileTextureViewModels}"
+                            VerticalAlignment="Top"
+                            HorizontalAlignment="Left"
+                            ItemContainerStyle="{StaticResource TileListItemContainerStyle}"
+                            MouseMove="TileTextureListView_OnMouseMove">
+                     <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                           <UniformGrid Columns="4" />
+                        </ItemsPanelTemplate>
+                     </ItemsControl.ItemsPanel>
+                     <ListView.ItemTemplate>
+                        <DataTemplate>
+                           <Image Source="{Binding Image}"
+                                  Width="32"
+                                  Height="32" />
+                        </DataTemplate>
+                     </ListView.ItemTemplate>
+                  </ListView>
+
+               </StackPanel> <!-- Tile Map Texture Editor Control Panel -->
+                  
+            </StackPanel>
+         </TabItem> <!-- Tile Map Texture Editor -->
+
+         <!-- Tile Map Portal Editor -->
+         <TabItem Header="Portals"
+                  IsSelected="True">
+            <StackPanel Orientation="Horizontal">
+                  
+               <!-- Source Portal Tiles -->
+               <StackPanel Orientation="Vertical">
+
                   <ListView ItemsSource="{Binding SelectedTileMap.Tiles}"
                             VerticalAlignment="Top"
                             HorizontalAlignment="Left"
-                            Width="{Binding TileMapTextureListViewWidth}"
-                            Height="{Binding TileMapTextureListViewHeight}"
+                            Width="{Binding TileMapPortalListViewWidth}"
+                            Height="{Binding TileMapPortalListViewHeight}"
                             ItemContainerStyle="{StaticResource TileListItemContainerStyle}"
-                            AllowDrop="True"
-                            PreviewMouseDown="TileMapTextureListView_OnPreviewMouseDown"
-                            MouseMove="TileMapTextureListView_OnMouseMove"
-                            Drop="TileMapTextureListView_OnDrop">
+                            SelectionChanged="TileMapPortalSourceListView_OnSelectionChanged">
                      <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate>
                            <UniformGrid Columns="{Binding SelectedTileMap.TilesX}"/>
@@ -78,149 +143,83 @@
                      </ItemsControl.ItemsPanel>
                      <ListView.ItemTemplate>
                         <DataTemplate>
-                           <Grid DragEnter="TileMapTextureListViewImage_OnDragEnter"
-                                 DragLeave="TileMapTextureListViewImage_OnDragLeave">
+                           <Grid>
                               <Image Source="{Binding Image}"
                                      Width="32"
-                                     Height="32"/>
+                                     Height="32" />
+                              <Rectangle Width="32"
+                                         Height="32"
+                                         Fill="#66FF00FF"
+                                         Visibility="{Binding HasPortal, Converter={StaticResource BoolToVisibilityConverter}}" />
                               <Rectangle Width="32"
                                          Height="32"
                                          Fill="#660000FF"
-                                         Visibility="{Binding IsDraggingTextureOver, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                         Visibility="{Binding IsSelected, Converter={StaticResource BoolToVisibilityConverter}}" />
                            </Grid>
                         </DataTemplate>
                      </ListView.ItemTemplate>
                   </ListView>
 
-                  <!-- Tile Map Texture Editor Control Panel -->
-                  <StackPanel Orientation="Vertical">
-
-                     <!-- Tile Map Texture Editor Texture Picker -->
-                     <ListView x:Name="tileTextureListView"
-                               ItemsSource="{Binding TileTextureViewModels}"
-                               VerticalAlignment="Top"
-                               HorizontalAlignment="Left"
-                               ItemContainerStyle="{StaticResource TileListItemContainerStyle}"
-                               MouseMove="TileTextureListView_OnMouseMove">
-                        <ItemsControl.ItemsPanel>
-                           <ItemsPanelTemplate>
-                              <UniformGrid Columns="4"/>
-                           </ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ListView.ItemTemplate>
-                           <DataTemplate>
-                              <Image Source="{Binding Image}"
-                                     Width="32"
-                                     Height="32"/>
-                           </DataTemplate>
-                        </ListView.ItemTemplate>
-                     </ListView>
-
-                  </StackPanel> <!-- Tile Map Texture Editor Control Panel -->
+               </StackPanel> <!-- Source Portal Tiles -->
                   
-               </StackPanel>
-            </TabItem> <!-- Tile Map Texture Editor -->
-
-            <!-- Tile Map Portal Editor -->
-            <TabItem Header="Portals"
-                     IsSelected="True">
-               <StackPanel Orientation="Horizontal">
-                  
-                  <!-- Source Portal Tiles -->
-                  <StackPanel Orientation="Vertical">
-
-                     <ListView ItemsSource="{Binding SelectedTileMap.Tiles}"
-                               VerticalAlignment="Top"
-                               HorizontalAlignment="Left"
-                               Width="{Binding TileMapPortalListViewWidth}"
-                               Height="{Binding TileMapPortalListViewHeight}"
-                               ItemContainerStyle="{StaticResource TileListItemContainerStyle}"
-                               SelectionChanged="TileMapPortalSourceListView_OnSelectionChanged">
-                        <ItemsControl.ItemsPanel>
-                           <ItemsPanelTemplate>
-                              <UniformGrid Columns="{Binding SelectedTileMap.TilesX}"/>
-                           </ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ListView.ItemTemplate>
-                           <DataTemplate>
-                              <Grid>
-                                 <Image Source="{Binding Image}"
-                                        Width="32"
-                                        Height="32"/>
-                                 <Rectangle Width="32"
-                                            Height="32"
-                                            Fill="#66FF00FF"
-                                            Visibility="{Binding HasPortal, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                 <Rectangle Width="32"
-                                            Height="32"
-                                            Fill="#660000FF"
-                                            Visibility="{Binding IsSelected, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                              </Grid>
-                           </DataTemplate>
-                        </ListView.ItemTemplate>
-                     </ListView>
-
-                  </StackPanel> <!-- Source Portal Tiles -->
-                  
-                  <!-- Source Portal Properties -->
-                  <StackPanel Orientation="Vertical"
-                              Visibility="{Binding TileIsSelected, Converter={StaticResource BoolToVisibilityConverter}}">
+               <!-- Source Portal Properties -->
+               <StackPanel Orientation="Vertical"
+                           Visibility="{Binding TileIsSelected, Converter={StaticResource BoolToVisibilityConverter}}">
                      
-                     <StackPanel Orientation="Vertical"
-                                 Visibility="{Binding SelectedTile.HasPortal, Converter={StaticResource InverseBoolToVisibilityConverter}}">
-                        <Button Content="Add Portal"
-                                Command="{Binding AddPortalCommand, Mode=OneTime}"/>
-                     </StackPanel>
-
-                     <StackPanel Orientation="Vertical"
-                                 Visibility="{Binding SelectedTile.HasPortal, Converter={StaticResource BoolToVisibilityConverter}}">
-                        <StackPanel Orientation="Horizontal">
-                           <TextBlock Text="Facing: "/>
-                           <ComboBox ItemsSource="{Binding PortalArrivalDirections}"
-                                  SelectedItem="{Binding SelectedPortalArrivalDirection}"/>
-                        </StackPanel>
-                        <Button Content="Delete This Portal"
-                                Command="{Binding DeleteSelectedPortalCommand, Mode=OneTime}"/>
-                     </StackPanel>
-
-                  </StackPanel> <!-- Source Portal Properties -->
-
-                  <!-- Destination Portal Tiles -->
                   <StackPanel Orientation="Vertical"
-                              Visibility="{Binding PortalIsSelected, Converter={StaticResource BoolToVisibilityConverter}}">
-                     <ListView ItemsSource="{Binding PortalDestinationTileMap.Tiles}"
-                               VerticalAlignment="Top"
-                               HorizontalAlignment="Left"
-                               Width="{Binding TileMapPortalDestinationListViewWidth}"
-                               Height="{Binding TileMapPortalDestinationListViewHeight}"
-                               ItemContainerStyle="{StaticResource TileListItemContainerStyle}"
-                               SelectionChanged="TileMapPortalDestinationListView_OnSelectionChanged">
-                        <ItemsControl.ItemsPanel>
-                           <ItemsPanelTemplate>
-                              <UniformGrid Columns="{Binding PortalDestinationTileMap.TilesX}"/>
-                           </ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ListView.ItemTemplate>
-                           <DataTemplate>
-                              <Grid>
-                                 <Image Source="{Binding Image}"
-                                        Width="32"
-                                        Height="32"/>
-                                 <Rectangle Width="32"
-                                            Height="32"
-                                            Fill="#66FF00FF"
-                                            Visibility="{Binding IsPortalDestination, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                              </Grid>
-                           </DataTemplate>
-                        </ListView.ItemTemplate>
-                     </ListView>
+                              Visibility="{Binding SelectedTile.HasPortal, Converter={StaticResource InverseBoolToVisibilityConverter}}">
+                     <Button Content="Add Portal"
+                             Command="{Binding AddPortalCommand, Mode=OneTime}" />
                   </StackPanel>
 
-               </StackPanel>
-            </TabItem> <!-- Tile Map Portal Editor -->
-            
-         </TabControl>
+                  <StackPanel Orientation="Vertical"
+                              Visibility="{Binding SelectedTile.HasPortal, Converter={StaticResource BoolToVisibilityConverter}}">
+                     <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="Facing: " />
+                        <ComboBox ItemsSource="{Binding PortalArrivalDirections}"
+                                  SelectedItem="{Binding SelectedPortalArrivalDirection}" />
+                     </StackPanel>
+                     <Button Content="Delete This Portal"
+                             Command="{Binding DeleteSelectedPortalCommand, Mode=OneTime}" />
+                  </StackPanel>
 
-      </StackPanel> <!-- Window Contents -->
-   </Grid>
+               </StackPanel> <!-- Source Portal Properties -->
+
+               <!-- Destination Portal Tiles -->
+               <StackPanel Orientation="Vertical"
+                           Visibility="{Binding PortalIsSelected, Converter={StaticResource BoolToVisibilityConverter}}">
+                  <ListView ItemsSource="{Binding PortalDestinationTileMap.Tiles}"
+                            VerticalAlignment="Top"
+                            HorizontalAlignment="Left"
+                            Width="{Binding TileMapPortalDestinationListViewWidth}"
+                            Height="{Binding TileMapPortalDestinationListViewHeight}"
+                            ItemContainerStyle="{StaticResource TileListItemContainerStyle}"
+                            SelectionChanged="TileMapPortalDestinationListView_OnSelectionChanged">
+                     <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                           <UniformGrid Columns="{Binding PortalDestinationTileMap.TilesX}" />
+                        </ItemsPanelTemplate>
+                     </ItemsControl.ItemsPanel>
+                     <ListView.ItemTemplate>
+                        <DataTemplate>
+                           <Grid>
+                              <Image Source="{Binding Image}"
+                                     Width="32"
+                                     Height="32" />
+                              <Rectangle Width="32"
+                                         Height="32"
+                                         Fill="#66FF00FF"
+                                         Visibility="{Binding IsPortalDestination, Converter={StaticResource BoolToVisibilityConverter}}" />
+                           </Grid>
+                        </DataTemplate>
+                     </ListView.ItemTemplate>
+                  </ListView>
+               </StackPanel>
+
+            </StackPanel>
+         </TabItem> <!-- Tile Map Portal Editor -->
+            
+      </TabControl>
+
+   </StackPanel> <!-- Window Contents -->
 </Window>

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
@@ -9,7 +9,8 @@
         Title="Dragon Questino Editor"
         Height="848"
         Width="1320"
-        ResizeMode="NoResize">
+		ResizeMode="NoResize"
+        FocusManager.FocusedElement="{Binding ElementName=MapPanel}">
    <Window.Resources>
       <ResourceDictionary>
          <Style x:Key="TileListItemContainerStyle"
@@ -61,7 +62,8 @@
             <StackPanel Orientation="Horizontal">
 
                <!-- Tile Map Texture Editor Tiles -->
-               <local:MapPanel TileMap="{Binding SelectedTileMap.Tiles}" />
+               <local:MapPanel x:Name="MapPanel"
+                               TileMap="{Binding SelectedTileMap.Tiles}" />
                
                <!--<ListView ItemsSource="{Binding SelectedTileMap.Tiles}"
                          VerticalAlignment="Top"

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
@@ -92,19 +92,23 @@
 
          <!-- Tile Map Portal Editor -->
          <TabItem Header="Portals">
-            <StackPanel Orientation="Horizontal">
+            <Grid>
+               <Grid.ColumnDefinitions>
+                  <ColumnDefinition />
+                  <ColumnDefinition Width="200" />
+                  <ColumnDefinition />
+               </Grid.ColumnDefinitions>
 
                <!-- Source Portal Tiles -->
-               <StackPanel Orientation="Vertical">
 
-                  <local:MapPanel TileMap="{Binding SelectedTileMap.Tiles}"
-                                  SelectedTextureIndex="{Binding SelectedItem.TextureIndex, ElementName=tileSelectionListView, Mode=TwoWay}" />
+               <local:MapPanel TileMap="{Binding SelectedTileMap.Tiles}"
+                               SelectedTextureIndex="{Binding SelectedItem.TextureIndex, ElementName=tileSelectionListView, Mode=TwoWay}" />
 
-               </StackPanel>
                <!-- Source Portal Tiles -->
 
                <!-- Source Portal Properties -->
-               <StackPanel Orientation="Vertical"
+               <StackPanel Grid.Column="1"
+                           Orientation="Vertical"
                            Visibility="{Binding TileIsSelected, Converter={StaticResource BoolToVisibilityConverter}}">
 
                   <StackPanel Orientation="Vertical"
@@ -128,21 +132,13 @@
                <!-- Source Portal Properties -->
 
                <!-- Destination Portal Tiles -->
-               <StackPanel Orientation="Vertical"
-                           Visibility="{Binding PortalIsSelected, Converter={StaticResource BoolToVisibilityConverter}}">
-
-                  <local:MapPanel TileMap="{Binding PortalDestinationTileMap.Tiles}"
-                                  SelectedTextureIndex="{Binding SelectedItem.TextureIndex, ElementName=tileSelectionListView, Mode=TwoWay}" />
-
-               </StackPanel>
-
-            </StackPanel>
+               <local:MapPanel Grid.Column="2"
+                               TileMap="{Binding PortalDestinationTileMap.Tiles}"
+                               SelectedTextureIndex="{Binding SelectedItem.TextureIndex, ElementName=tileSelectionListView, Mode=TwoWay}" />
+            </Grid>
          </TabItem>
          <!-- Tile Map Portal Editor -->
-
       </TabControl>
-
-
    </Grid>
    <!-- Window Contents -->
 </Window>

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
@@ -9,7 +9,7 @@
         Title="Dragon Questino Editor"
         Height="848"
         Width="1320"
-		  ResizeMode="NoResize"
+        ResizeMode="NoResize"
         FocusManager.FocusedElement="{Binding ElementName=MapPanel}">
    <Window.Resources>
       <DragonQuestinoEditorConverters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"
@@ -19,9 +19,13 @@
                                                                 TrueValue="Collapsed"
                                                                 FalseValue="Visible" />
    </Window.Resources>
-   
+
    <!-- Window Contents -->
-   <StackPanel Orientation="Vertical">
+   <Grid>
+      <Grid.RowDefinitions>
+         <RowDefinition Height="30" />
+         <RowDefinition />
+      </Grid.RowDefinitions>
 
       <!-- Tile Map Operations -->
       <StackPanel Orientation="Horizontal">
@@ -39,12 +43,16 @@
       </StackPanel>
 
       <!-- Tile Map Tabs -->
-      <TabControl>
+      <TabControl Grid.Row="1">
 
          <!-- Tile Map Texture Editor -->
          <TabItem Header="Textures"
                   IsSelected="True">
-            <StackPanel Orientation="Horizontal">
+            <Grid>
+               <Grid.ColumnDefinitions>
+                  <ColumnDefinition />
+                  <ColumnDefinition Width="Auto" />
+               </Grid.ColumnDefinitions>
 
                <!-- Tile Map Texture Editor Tiles -->
                <local:MapPanel x:Name="MapPanel"
@@ -52,7 +60,8 @@
                                SelectedTextureIndex="{Binding SelectedItem.TextureIndex, ElementName=tileSelectionListView, Mode=TwoWay}" />
 
                <!-- Tile Map Texture Editor Control Panel -->
-               <StackPanel Orientation="Vertical">
+               <StackPanel Grid.Column="1"
+                           Orientation="Vertical">
 
                   <!-- Tile Map Texture Editor Texture Picker -->
                   <ListBox x:Name="tileSelectionListView"
@@ -75,27 +84,29 @@
                      </ListBox.ItemTemplate>
                   </ListBox>
 
-               </StackPanel> <!-- Tile Map Texture Editor Control Panel -->
-                  
-            </StackPanel>
-         </TabItem> <!-- Tile Map Texture Editor -->
+               </StackPanel>
+               <!-- Tile Map Texture Editor Control Panel -->
+            </Grid>
+         </TabItem>
+         <!-- Tile Map Texture Editor -->
 
          <!-- Tile Map Portal Editor -->
          <TabItem Header="Portals">
             <StackPanel Orientation="Horizontal">
-                  
+
                <!-- Source Portal Tiles -->
                <StackPanel Orientation="Vertical">
 
                   <local:MapPanel TileMap="{Binding SelectedTileMap.Tiles}"
                                   SelectedTextureIndex="{Binding SelectedItem.TextureIndex, ElementName=tileSelectionListView, Mode=TwoWay}" />
 
-               </StackPanel> <!-- Source Portal Tiles -->
-                  
+               </StackPanel>
+               <!-- Source Portal Tiles -->
+
                <!-- Source Portal Properties -->
                <StackPanel Orientation="Vertical"
                            Visibility="{Binding TileIsSelected, Converter={StaticResource BoolToVisibilityConverter}}">
-                     
+
                   <StackPanel Orientation="Vertical"
                               Visibility="{Binding SelectedTile.HasPortal, Converter={StaticResource InverseBoolToVisibilityConverter}}">
                      <Button Content="Add Portal"
@@ -113,7 +124,8 @@
                              Command="{Binding DeleteSelectedPortalCommand, Mode=OneTime}" />
                   </StackPanel>
 
-               </StackPanel> <!-- Source Portal Properties -->
+               </StackPanel>
+               <!-- Source Portal Properties -->
 
                <!-- Destination Portal Tiles -->
                <StackPanel Orientation="Vertical"
@@ -125,9 +137,12 @@
                </StackPanel>
 
             </StackPanel>
-         </TabItem> <!-- Tile Map Portal Editor -->
-            
+         </TabItem>
+         <!-- Tile Map Portal Editor -->
+
       </TabControl>
 
-   </StackPanel> <!-- Window Contents -->
+
+   </Grid>
+   <!-- Window Contents -->
 </Window>

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
@@ -49,7 +49,8 @@
 
                <!-- Tile Map Texture Editor Tiles -->
                <local:MapPanel x:Name="MapPanel"
-                               TileMap="{Binding SelectedTileMap.Tiles}" />
+                               TileMap="{Binding SelectedTileMap.Tiles}"
+                               SelectedPaintingIndex="{Binding SelectedItem.TextureIndex, ElementName=tileSelectionListView, Mode=TwoWay}" />
                
                <!--<ListView ItemsSource="{Binding SelectedTileMap.Tiles}"
                          VerticalAlignment="Top"
@@ -104,22 +105,6 @@
                                   Height="32" />
                         </DataTemplate>
                      </ListBox.ItemTemplate>
-
-                     <ListBox.ItemContainerStyle>
-                        <Style TargetType="{x:Type ListBoxItem}">
-                           <Setter Property="Background"
-                                   Value="Transparent" />
-                           <Setter Property="FocusVisualStyle"
-                                   Value="{x:Null}" />
-                           <Setter Property="Template">
-                              <Setter.Value>
-                                 <ControlTemplate TargetType="{x:Type ListBoxItem}">
-                                    <ContentPresenter />
-                                 </ControlTemplate>
-                              </Setter.Value>
-                           </Setter>
-                        </Style>
-                     </ListBox.ItemContainerStyle>
                   </ListBox>
 
                </StackPanel> <!-- Tile Map Texture Editor Control Panel -->
@@ -135,7 +120,8 @@
                <!-- Source Portal Tiles -->
                <StackPanel Orientation="Vertical">
 
-                  <local:MapPanel TileMap="{Binding TileMapViewModels}" />
+                  <local:MapPanel TileMap="{Binding TileMapViewModels}"
+                                  SelectedPaintingIndex="{Binding SelectedItem.TextureIndex, ElementName=tileSelectionListView, Mode=TwoWay}" />
                   
                   <!--<ListView ItemsSource="{Binding SelectedTileMap.Tiles}"
                             VerticalAlignment="Top"

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml
@@ -61,7 +61,9 @@
             <StackPanel Orientation="Horizontal">
 
                <!-- Tile Map Texture Editor Tiles -->
-               <ListView ItemsSource="{Binding SelectedTileMap.Tiles}"
+               <local:MapPanel TileMap="{Binding SelectedTileMap.Tiles}" />
+               
+               <!--<ListView ItemsSource="{Binding SelectedTileMap.Tiles}"
                          VerticalAlignment="Top"
                          HorizontalAlignment="Left"
                          Width="{Binding TileMapTextureListViewWidth}"
@@ -90,7 +92,7 @@
                         </Grid>
                      </DataTemplate>
                   </ListView.ItemTemplate>
-               </ListView>
+               </ListView>-->
 
                <!-- Tile Map Texture Editor Control Panel -->
                <StackPanel Orientation="Vertical">
@@ -129,7 +131,9 @@
                <!-- Source Portal Tiles -->
                <StackPanel Orientation="Vertical">
 
-                  <ListView ItemsSource="{Binding SelectedTileMap.Tiles}"
+                  <local:MapPanel TileMap="{Binding TileMapViewModels}" />
+                  
+                  <!--<ListView ItemsSource="{Binding SelectedTileMap.Tiles}"
                             VerticalAlignment="Top"
                             HorizontalAlignment="Left"
                             Width="{Binding TileMapPortalListViewWidth}"
@@ -158,7 +162,7 @@
                            </Grid>
                         </DataTemplate>
                      </ListView.ItemTemplate>
-                  </ListView>
+                  </ListView>-->
 
                </StackPanel> <!-- Source Portal Tiles -->
                   

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MainWindow.xaml.cs
@@ -79,7 +79,7 @@ namespace DragonQuestinoEditor
 
             if ( tileVM is not null && tileVM.TextureIndex != _tileIndexCache )
             {
-               tileVM.SetTextureIndex( _tileIndexCache );
+               tileVM.TextureIndex = _tileIndexCache;
             }
          }
       }
@@ -92,7 +92,7 @@ namespace DragonQuestinoEditor
 
             if ( mapTileVM is not null )
             {
-               mapTileVM.SetTextureIndex( droppedTileTextureVM.Index );
+               mapTileVM.TextureIndex = droppedTileTextureVM.Index;
                mapTileVM.IsDraggingTextureOver = false;
             }
          }

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
@@ -182,7 +182,7 @@ namespace DragonQuestinoEditor
          int offset = _cellY * _tilesPerRow + _cellX;
          var tileViewModel = TileMap[offset];
 
-         if ( tileViewModel.Index == SelectedPaintingIndex)
+         if (tileViewModel.Index == SelectedPaintingIndex)
          {
             // No need to redraw the tile if it's the same
             return;
@@ -226,9 +226,18 @@ namespace DragonQuestinoEditor
          SetZoomLevel( delta );
       }
 
+      protected override void OnMouseEnter( MouseEventArgs e )
+      {
+         base.OnMouseEnter( e );
+
+         // Mousing over the control steals focus so the keyboard events will work
+         Focus();
+      }
+
       protected override void OnMouseLeftButtonDown( MouseButtonEventArgs e )
       {
          base.OnMouseLeftButtonDown( e );
+
          _isLeftButtonDown = true;
 
          switch (_inputMode)

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
@@ -2,14 +2,20 @@
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Media.Imaging;
 using DragonQuestinoEditor.ViewModels;
 
 namespace DragonQuestinoEditor
 {
    internal class MapPanel : FrameworkElement
    {
+      private readonly SolidColorBrush _background = new SolidColorBrush( Color.FromRgb( 64, 64, 64 ) );
+
       private bool _isLeftButtonDown;
       private Point _dragAnchorPoint;
+
+      private WriteableBitmap? _bitmap;
+      private byte[]? _rawBuffer;
 
       private static readonly DependencyProperty OffsetProperty = DependencyProperty.Register(
          nameof( Offset ),
@@ -27,12 +33,58 @@ namespace DragonQuestinoEditor
          nameof( TileMap ),
          typeof( Collection<TileViewModel> ),
          typeof( MapPanel ),
-         new FrameworkPropertyMetadata( null, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsArrange ) );
+         new PropertyMetadata( OnTileMapChanged ) );
+
+      private static void OnTileMapChanged( DependencyObject obj, DependencyPropertyChangedEventArgs e )
+      {
+         if (obj is not MapPanel sender || e.NewValue is not Collection<TileViewModel> tileMap)
+         {
+            return;
+         }
+
+         sender.PrepareBitmap();
+      }
 
       public Collection<TileViewModel> TileMap
       {
          get => (Collection<TileViewModel>)GetValue( TileMapProperty );
          set => SetValue( TileMapProperty, value );
+      }
+
+      public MapPanel()
+      {
+         ClipToBounds = true;
+      }
+
+      private void PrepareBitmap()
+      {
+         const int tilesPerRow = 140;
+         const int tileWidthInPixels = 16;
+         const int tileHeightInPixels = 16;
+         const int bytesPerPixel = 4;
+
+         int width = tilesPerRow * tileWidthInPixels * bytesPerPixel;
+         int height = tilesPerRow * tileHeightInPixels * bytesPerPixel;
+
+         _bitmap = new WriteableBitmap( width, height, 96, 96, PixelFormats.Bgra32, null );
+         _rawBuffer = new byte[width * height];
+
+         for (int i = 0; i < TileMap.Count; i++)
+         {
+            int cellX = i % tilesPerRow;
+            int cellY = i / tilesPerRow;
+
+            int destX = cellX * tileWidthInPixels * bytesPerPixel;
+            int destY = cellY * tileWidthInPixels;
+
+            int tileIndex = TileMap[i].Index;
+            var tile = TileMap[i].TileSet.Tiles[tileIndex];
+
+            tile.DrawToBuffer( _rawBuffer, width, destX, destY );
+         }
+
+         // I don't know why I have to divide by 4 on the width, height
+         _bitmap.WritePixels( new Int32Rect( 0, 0, _bitmap.PixelWidth / 4, _bitmap.PixelHeight / 4 ), _rawBuffer, _bitmap.PixelWidth, 0 );
       }
 
       protected override void OnMouseLeftButtonDown( MouseButtonEventArgs e )
@@ -61,26 +113,13 @@ namespace DragonQuestinoEditor
 
       protected override void OnRender( DrawingContext dc )
       {
-         if (TileMap is null || TileMap.Count == 0)
+         dc.DrawRectangle( _background, null, new Rect( 0, 0, ActualWidth, ActualHeight ) );
+
+         if (_bitmap is not null)
          {
-            return;
-         }
-
-         dc.DrawRectangle( Brushes.DarkSlateGray, null, new Rect( 0, 0, ActualWidth, ActualHeight ) );
-
-         for (int i = 0; i < TileMap.Count; i++)
-         {
-            var tile = TileMap[i];
-
-            int width = (int)tile.Image.Width;
-            int height = (int)tile.Image.Height;
-
-            var offset = Offset;
-
-            int x = (int)offset.X + (i % 140) * width;
-            int y = (int)offset.Y + (i / 140) * height;
-
-            dc.DrawImage( tile.Image, new Rect( x, y, width, height ) );
+            dc.PushTransform( new ScaleTransform( _zoom, _zoom ) );
+            dc.DrawImage( _bitmap, new Rect( Offset.X, Offset.Y, _bitmap.Width, _bitmap.Height ) );
+            dc.Pop();
          }
       }
    }

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
@@ -30,6 +30,8 @@ namespace DragonQuestinoEditor
 
       private bool _isAnimatingZooming;
 
+      private InputMode _inputMode;
+
       private static readonly DependencyProperty ZoomProperty = DependencyProperty.Register(
          nameof( Zoom ),
          typeof( double ),
@@ -91,6 +93,7 @@ namespace DragonQuestinoEditor
       public MapPanel()
       {
          ClipToBounds = true;
+         Focusable = true;
       }
 
       /// <summary>
@@ -155,6 +158,23 @@ namespace DragonQuestinoEditor
          }
       }
 
+      protected override void OnPreviewKeyDown( KeyEventArgs e )
+      {
+         if (e.Key == Key.Space)
+         {
+            _inputMode = InputMode.Pan;
+            Cursor = Cursors.ScrollAll;
+         }
+      }
+
+      protected override void OnPreviewKeyUp( KeyEventArgs e )
+      {
+         base.OnPreviewKeyUp( e );
+
+         _inputMode = InputMode.Draw;
+         Cursor = Cursors.Arrow;
+      }
+
       protected override void OnMouseWheel( MouseWheelEventArgs e )
       {
          base.OnMouseWheel( e );
@@ -167,10 +187,17 @@ namespace DragonQuestinoEditor
       {
          base.OnMouseLeftButtonDown( e );
 
-         _isLeftButtonDown = true;
-         CaptureMouse();
+         switch (_inputMode)
+         {
+            case InputMode.Pan:
+            {
+               _isLeftButtonDown = true;
+               CaptureMouse();
+               _dragAnchorPoint = e.GetPosition( this ) - Offset;
 
-         _dragAnchorPoint = e.GetPosition( this ) - Offset;
+               break;
+            }
+         }
       }
 
       protected override void OnMouseMove( MouseEventArgs e )
@@ -225,7 +252,7 @@ namespace DragonQuestinoEditor
             dc.PushTransform( transform );
             dc.DrawImage( _bitmap, new Rect( 0, 0, _bitmap.Width, _bitmap.Height ) );
 
-            if (TileHighlight != Rect.Empty)
+            if (TileHighlight != Rect.Empty && _inputMode == InputMode.Draw)
             {
                dc.DrawRectangle( _highlight, null, TileHighlight );
             }

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
@@ -93,6 +93,17 @@ namespace DragonQuestinoEditor
          set => SetValue( TileMapProperty, value );
       }
 
+      public static readonly DependencyProperty SelectedPaintingIndexProperty = DependencyProperty.Register(
+         nameof( SelectedPaintingIndex ),
+         typeof( int ),
+         typeof( MapPanel ) );
+
+      public int SelectedPaintingIndex
+      {
+         get => (int)GetValue( SelectedPaintingIndexProperty );
+         set => SetValue( SelectedPaintingIndexProperty, value );
+      }
+
       public MapPanel()
       {
          ClipToBounds = true;
@@ -201,7 +212,7 @@ namespace DragonQuestinoEditor
 
                int offset = _cellY * _tilesPerRow + _cellX;
                var tileViewModel = TileMap[offset];
-               tileViewModel.SetIndex( 1 );
+               tileViewModel.Index = SelectedPaintingIndex;
 
                var byteBuffer = new byte[_defaultTileSize * _defaultTileSize * 4];
                var tileSprite = TileMap[tileViewModel.Index].TileSet.Tiles[tileViewModel.Index];

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
@@ -8,7 +8,7 @@ using DragonQuestinoEditor.ViewModels;
 
 namespace DragonQuestinoEditor
 {
-   internal class MapPanel : FrameworkElement
+   public class MapPanel : FrameworkElement
    {
       private const int _tilesPerRow = 140;
       private const int _defaultTileSize = 16;
@@ -93,15 +93,15 @@ namespace DragonQuestinoEditor
          set => SetValue( TileMapProperty, value );
       }
 
-      public static readonly DependencyProperty SelectedPaintingIndexProperty = DependencyProperty.Register(
-         nameof( SelectedPaintingIndex ),
+      public static readonly DependencyProperty SelectedTextureIndexProperty = DependencyProperty.Register(
+         nameof( SelectedTextureIndex ),
          typeof( int ),
          typeof( MapPanel ) );
 
-      public int SelectedPaintingIndex
+      public int SelectedTextureIndex
       {
-         get => (int)GetValue( SelectedPaintingIndexProperty );
-         set => SetValue( SelectedPaintingIndexProperty, value );
+         get => (int)GetValue( SelectedTextureIndexProperty );
+         set => SetValue( SelectedTextureIndexProperty, value );
       }
 
       public MapPanel()
@@ -138,13 +138,17 @@ namespace DragonQuestinoEditor
             int destX = cellX * _defaultTileSize * bytesPerPixel;
             int destY = cellY * _defaultTileSize;
 
-            int tileIndex = TileMap[i].Index;
-            var tile = TileMap[i].TileSet.Tiles[tileIndex];
+            int textureIndex = TileMap[i].TextureIndex;
+            var tile = TileMap[i].TileSet.TileTextures[textureIndex];
 
             tile.DrawToBuffer( _rawBuffer, width, destX, destY );
          }
 
          // I don't know why I have to divide by 4 on the width, height
+         // Steve note: it's probably something to do with the "stride" value, you're
+         // sending in the width, but I think they want the actual number of bytes per line.
+         // that would be width * (bpp / 8), so width * 4, although if you change that you'd
+         // also need to update other stuff in here, like the size of _rawBuffer.
          _bitmap.WritePixels( new Int32Rect( 0, 0, _bitmap.PixelWidth / 4, _bitmap.PixelHeight / 4 ), _rawBuffer, _bitmap.PixelWidth, 0 );
       }
 
@@ -174,7 +178,7 @@ namespace DragonQuestinoEditor
 
       private void ChangeTile()
       {
-         if (_bitmap is null)
+         if ( _bitmap is null )
          {
             return;
          }
@@ -182,16 +186,16 @@ namespace DragonQuestinoEditor
          int offset = _cellY * _tilesPerRow + _cellX;
          var tileViewModel = TileMap[offset];
 
-         if (tileViewModel.Index == SelectedPaintingIndex)
+         if ( tileViewModel.TextureIndex == SelectedTextureIndex )
          {
             // No need to redraw the tile if it's the same
             return;
          }
 
-         tileViewModel.Index = SelectedPaintingIndex;
+         tileViewModel.TextureIndex = SelectedTextureIndex;
 
          var byteBuffer = new byte[_defaultTileSize * _defaultTileSize * 4];
-         var tileSprite = TileMap[tileViewModel.Index].TileSet.Tiles[tileViewModel.Index];
+         var tileSprite = TileMap[tileViewModel.TextureIndex].TileSet.TileTextures[tileViewModel.TextureIndex];
          tileSprite.DrawToBuffer( byteBuffer, _defaultTileSize * 4, 0, 0 );
 
          int destX = _cellX * 16;
@@ -203,7 +207,7 @@ namespace DragonQuestinoEditor
 
       protected override void OnPreviewKeyDown( KeyEventArgs e )
       {
-         if (e.Key == Key.Space)
+         if ( e.Key == Key.Space )
          {
             _inputMode = InputMode.Pan;
             Cursor = Cursors.ScrollAll;
@@ -240,7 +244,7 @@ namespace DragonQuestinoEditor
 
          _isLeftButtonDown = true;
 
-         switch (_inputMode)
+         switch ( _inputMode )
          {
             case InputMode.Draw:
             {

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.ObjectModel;
 using System.Windows;
+using System.Windows.Input;
 using System.Windows.Media;
 using DragonQuestinoEditor.ViewModels;
 
@@ -7,6 +8,21 @@ namespace DragonQuestinoEditor
 {
    internal class MapPanel : FrameworkElement
    {
+      private bool _isLeftButtonDown;
+      private Point _dragAnchorPoint;
+
+      private static readonly DependencyProperty OffsetProperty = DependencyProperty.Register(
+         nameof( Offset ),
+         typeof( Vector ),
+         typeof( MapPanel ),
+         new FrameworkPropertyMetadata( new Vector( 0, 0 ), FrameworkPropertyMetadataOptions.AffectsRender ) );
+
+      public Vector Offset
+      {
+         get => (Vector)GetValue( OffsetProperty );
+         set => SetValue( OffsetProperty, value );
+      }
+
       public static readonly DependencyProperty TileMapProperty = DependencyProperty.Register(
          nameof( TileMap ),
          typeof( Collection<TileViewModel> ),
@@ -17,6 +33,30 @@ namespace DragonQuestinoEditor
       {
          get => (Collection<TileViewModel>)GetValue( TileMapProperty );
          set => SetValue( TileMapProperty, value );
+      }
+
+      protected override void OnMouseLeftButtonDown( MouseButtonEventArgs e )
+      {
+         base.OnMouseLeftButtonDown( e );
+
+         _isLeftButtonDown = true;
+         _dragAnchorPoint = e.GetPosition( this ) - Offset;
+      }
+
+      protected override void OnMouseMove( MouseEventArgs e )
+      {
+         base.OnMouseMove( e );
+
+         if (_isLeftButtonDown)
+         {
+            Offset = e.GetPosition( this ) - _dragAnchorPoint;
+         }
+      }
+
+      protected override void OnMouseLeftButtonUp( MouseButtonEventArgs e )
+      {
+         base.OnMouseLeftButtonUp( e );
+         _isLeftButtonDown = false;
       }
 
       protected override void OnRender( DrawingContext dc )
@@ -35,8 +75,10 @@ namespace DragonQuestinoEditor
             int width = (int)tile.Image.Width;
             int height = (int)tile.Image.Height;
 
-            int x = (i % 140) * width;
-            int y = (i / 140) * height;
+            var offset = Offset;
+
+            int x = (int)offset.X + (i % 140) * width;
+            int y = (int)offset.Y + (i / 140) * height;
 
             dc.DrawImage( tile.Image, new Rect( x, y, width, height ) );
          }

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
@@ -92,6 +92,8 @@ namespace DragonQuestinoEditor
          base.OnMouseLeftButtonDown( e );
 
          _isLeftButtonDown = true;
+         CaptureMouse();
+
          _dragAnchorPoint = e.GetPosition( this ) - Offset;
       }
 
@@ -108,6 +110,8 @@ namespace DragonQuestinoEditor
       protected override void OnMouseLeftButtonUp( MouseButtonEventArgs e )
       {
          base.OnMouseLeftButtonUp( e );
+         ReleaseMouseCapture();
+
          _isLeftButtonDown = false;
       }
 

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
@@ -30,6 +30,9 @@ namespace DragonQuestinoEditor
 
       private bool _isAnimatingZooming;
 
+      private int _cellX;
+      private int _cellY;
+
       private InputMode _inputMode;
 
       private static readonly DependencyProperty ZoomProperty = DependencyProperty.Register(
@@ -189,6 +192,29 @@ namespace DragonQuestinoEditor
 
          switch (_inputMode)
          {
+            case InputMode.Draw:
+            {
+               if (_bitmap is null)
+               {
+                  return;
+               }
+
+               int offset = _cellY * _tilesPerRow + _cellX;
+               var tileViewModel = TileMap[offset];
+               tileViewModel.SetIndex( 1 );
+
+               var byteBuffer = new byte[_defaultTileSize * _defaultTileSize * 4];
+               var tileSprite = TileMap[tileViewModel.Index].TileSet.Tiles[tileViewModel.Index];
+               tileSprite.DrawToBuffer( byteBuffer, _defaultTileSize * 4, 0, 0 );
+
+               int destX = _cellX * 16;
+               int destY = _cellY * 16;
+
+               _bitmap.WritePixels( new Int32Rect( destX, destY, _defaultTileSize, _defaultTileSize ), byteBuffer, _defaultTileSize * 4, 0 );
+               InvalidateVisual();
+
+               break;
+            }
             case InputMode.Pan:
             {
                _isLeftButtonDown = true;
@@ -215,10 +241,10 @@ namespace DragonQuestinoEditor
          if (mapRect.Contains( mousePos ))
          {
             var tileSize = GetCurrentTileSize();
-            int cellX = (int)((mousePos.X - Offset.X * Zoom) / tileSize.Width);
-            int cellY = (int)((mousePos.Y - Offset.Y * Zoom) / tileSize.Height);
+            _cellX = (int)((mousePos.X - Offset.X * Zoom) / tileSize.Width);
+            _cellY = (int)((mousePos.Y - Offset.Y * Zoom) / tileSize.Height);
 
-            TileHighlight = new Rect( cellX * _defaultTileSize, cellY * _defaultTileSize, _defaultTileSize, _defaultTileSize );
+            TileHighlight = new Rect( _cellX * _defaultTileSize, _cellY * _defaultTileSize, _defaultTileSize, _defaultTileSize );
          }
          else
          {

--- a/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/MapPanel.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.ObjectModel;
+using System.Windows;
+using System.Windows.Media;
+using DragonQuestinoEditor.ViewModels;
+
+namespace DragonQuestinoEditor
+{
+   internal class MapPanel : FrameworkElement
+   {
+      public static readonly DependencyProperty TileMapProperty = DependencyProperty.Register(
+         nameof( TileMap ),
+         typeof( Collection<TileViewModel> ),
+         typeof( MapPanel ),
+         new FrameworkPropertyMetadata( null, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsArrange ) );
+
+      public Collection<TileViewModel> TileMap
+      {
+         get => (Collection<TileViewModel>)GetValue( TileMapProperty );
+         set => SetValue( TileMapProperty, value );
+      }
+
+      protected override void OnRender( DrawingContext dc )
+      {
+         if (TileMap is null || TileMap.Count == 0)
+         {
+            return;
+         }
+
+         dc.DrawRectangle( Brushes.DarkSlateGray, null, new Rect( 0, 0, ActualWidth, ActualHeight ) );
+
+         for (int i = 0; i < TileMap.Count; i++)
+         {
+            var tile = TileMap[i];
+
+            int width = (int)tile.Image.Width;
+            int height = (int)tile.Image.Height;
+
+            int x = (i % 140) * width;
+            int y = (i / 140) * height;
+
+            dc.DrawImage( tile.Image, new Rect( x, y, width, height ) );
+         }
+      }
+   }
+}

--- a/DragonQuestinoEditor/DragonQuestinoEditor/ViewModels/MainWindowViewModel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/ViewModels/MainWindowViewModel.cs
@@ -161,19 +161,20 @@ namespace DragonQuestinoEditor.ViewModels
 
          for ( int i = 0; i < Constants.TileTextureCount; i++ )
          {
-            var image = new BitmapImage();
+            // TODO: Unused?
+            //var image = new BitmapImage();
 
-            using var stream = new MemoryStream();
-            {
-               var encoder = new PngBitmapEncoder();
-               encoder.Frames.Add( BitmapFrame.Create( _tileSet.TileBitmaps[i] ) );
-               encoder.Save( stream );
-               image.BeginInit();
-               image.CacheOption = BitmapCacheOption.OnLoad;
-               image.StreamSource = stream;
-               image.EndInit();
-               image.Freeze();
-            }
+            //using var stream = new MemoryStream();
+            //{
+            //   var encoder = new PngBitmapEncoder();
+            //   encoder.Frames.Add( BitmapFrame.Create( _tileSet.TileBitmaps[i] ) );
+            //   encoder.Save( stream );
+            //   image.BeginInit();
+            //   image.CacheOption = BitmapCacheOption.OnLoad;
+            //   image.StreamSource = stream;
+            //   image.EndInit();
+            //   image.Freeze();
+            //}
 
             TileTextureViewModels.Add( new( _tileSet, i ) );
          }

--- a/DragonQuestinoEditor/DragonQuestinoEditor/ViewModels/MainWindowViewModel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/ViewModels/MainWindowViewModel.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections.ObjectModel;
-using System.IO;
 using System.Windows;
 using System.Windows.Input;
-using System.Windows.Media.Imaging;
 using DragonQuestinoEditor.Commands;
 using DragonQuestinoEditor.FileOps;
 using DragonQuestinoEditor.Graphics;
@@ -161,25 +159,10 @@ namespace DragonQuestinoEditor.ViewModels
 
          for ( int i = 0; i < Constants.TileTextureCount; i++ )
          {
-            // TODO: Unused?
-            //var image = new BitmapImage();
-
-            //using var stream = new MemoryStream();
-            //{
-            //   var encoder = new PngBitmapEncoder();
-            //   encoder.Frames.Add( BitmapFrame.Create( _tileSet.TileBitmaps[i] ) );
-            //   encoder.Save( stream );
-            //   image.BeginInit();
-            //   image.CacheOption = BitmapCacheOption.OnLoad;
-            //   image.StreamSource = stream;
-            //   image.EndInit();
-            //   image.Freeze();
-            //}
-
             TileTextureViewModels.Add( new( _tileSet, i ) );
          }
 
-         if ( !SaveDataFileOps.LoadData( Constants.EditorSaveDataFilePath, TileMaps ) )
+         if ( !SaveDataFileOps.LoadData( Constants.EditorSaveDataFilePath, _tileSet, TileMaps ) )
          {
             MessageBox.Show( "Could not load editor save file!" );
          }
@@ -241,7 +224,7 @@ namespace DragonQuestinoEditor.ViewModels
          if ( result.HasValue && result.Value )
          {
             int id = TileMaps[^1].Id + 1;
-            var newTileMap = new TileMapViewModel( id, window.NewTileMapName, window.NewTilesX, window.NewTilesY, Constants.TileTextureDefaultIndex );
+            var newTileMap = new TileMapViewModel( _tileSet, id, window.NewTileMapName, window.NewTilesX, window.NewTilesY, Constants.TileTextureDefaultIndex );
 
             foreach ( var tile in newTileMap.Tiles )
             {

--- a/DragonQuestinoEditor/DragonQuestinoEditor/ViewModels/TileMapViewModel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/ViewModels/TileMapViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using DragonQuestinoEditor.FileOps;
+using DragonQuestinoEditor.Graphics;
 using System.Collections.ObjectModel;
 
 namespace DragonQuestinoEditor.ViewModels
@@ -38,7 +39,7 @@ namespace DragonQuestinoEditor.ViewModels
          set => SetProperty( ref _name, value );
       }
 
-      public TileMapViewModel( int id, string? name, int tilesX, int tilesY, int defaultTileTextureIndex )
+      public TileMapViewModel( TileSet tileSet, int id, string? name, int tilesX, int tilesY, int defaultTileTextureIndex )
       {
          _id = id;
          _name = name;
@@ -47,11 +48,11 @@ namespace DragonQuestinoEditor.ViewModels
 
          for( int i = 0; i < tilesX * tilesY; i++ )
          {
-            Tiles.Add( new TileViewModel( defaultTileTextureIndex ) );
+            Tiles.Add( new TileViewModel( tileSet, defaultTileTextureIndex ) );
          }
       }
 
-      public TileMapViewModel( TileMapSaveData saveData )
+      public TileMapViewModel( TileSet tileSet, TileMapSaveData saveData )
       {
          _id = saveData.Id;
          _name = saveData.Name;
@@ -60,7 +61,7 @@ namespace DragonQuestinoEditor.ViewModels
 
          foreach ( var tileSaveData in saveData.Tiles )
          {
-            Tiles.Add( new( tileSaveData ) );
+            Tiles.Add( new( tileSet, tileSaveData ) );
          }
 
          foreach ( var portal in saveData.Portals )

--- a/DragonQuestinoEditor/DragonQuestinoEditor/ViewModels/TileViewModel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/ViewModels/TileViewModel.cs
@@ -22,11 +22,18 @@ namespace DragonQuestinoEditor.ViewModels
 
       public TileSet TileSet { get; }
 
-      private int _textureIndex;
-      public int TextureIndexIndex
+      private int _textureIndex = -1;
+      public int TextureIndex
       {
          get => _textureIndex;
-         private set => SetProperty( ref _textureIndex, value );
+         set
+         {
+            if ( SetProperty( ref _textureIndex, value ) )
+            {
+               Image = TileSet.TileBitmaps[value];
+               IsPassable = _passableTextureIndexes.Contains( value );
+            }
+         }
       }
 
       public BitmapSource? Image => _textureProvider?.GetImageFromIndex( TextureIndex );
@@ -49,7 +56,7 @@ namespace DragonQuestinoEditor.ViewModels
       public bool IsSelected
       {
          TileSet = tileSet;
-         SetIndex( index );
+         Index = index;
 
          _isPassable = _passableIndexes.Contains( index );
       }
@@ -74,10 +81,10 @@ namespace DragonQuestinoEditor.ViewModels
 
       public bool HasPortal => _portal is not null;
 
-      public TileViewModel( int index )
+      public TileViewModel( int textureIndex )
       {
-         SetTextureIndex( index );
-         _isPassable = _passableTextureIndexes.Contains( index );
+         TextureIndex = textureIndex;
+         _isPassable = _passableTextureIndexes.Contains( textureIndex );
       }
 
       public TileViewModel( TileSaveData saveData )
@@ -87,13 +94,5 @@ namespace DragonQuestinoEditor.ViewModels
       }
 
       public void SetTextureProvider( ITileTextureProvider? provider ) => _textureProvider = provider;
-
-      public void SetTextureIndex( int index )
-      {
-         TextureIndex = index;
-         Image = TileSet.TileBitmaps[index];
-         IsPassable = _passableTextureIndexes.Contains( index );
-         OnPropertyChanged( nameof( Image ) );
-      }
    }
 }

--- a/DragonQuestinoEditor/DragonQuestinoEditor/ViewModels/TileViewModel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/ViewModels/TileViewModel.cs
@@ -36,7 +36,12 @@ namespace DragonQuestinoEditor.ViewModels
          }
       }
 
-      public BitmapSource? Image => _textureProvider?.GetImageFromIndex( TextureIndex );
+      private BitmapSource? _image;
+      public BitmapSource? Image
+      {
+         get => _image;
+         private set => SetProperty( ref _image, value );
+      }
 
       private bool _isPassable;
       public bool IsPassable
@@ -55,10 +60,8 @@ namespace DragonQuestinoEditor.ViewModels
       private bool _isSelected = false;
       public bool IsSelected
       {
-         TileSet = tileSet;
-         Index = index;
-
-         _isPassable = _passableIndexes.Contains( index );
+         get => _isSelected;
+         set => SetProperty( ref _isSelected, value );
       }
 
       private bool _isPortalDestination = false;
@@ -81,15 +84,17 @@ namespace DragonQuestinoEditor.ViewModels
 
       public bool HasPortal => _portal is not null;
 
-      public TileViewModel( int textureIndex )
+      public TileViewModel( TileSet tileSet, int textureIndex )
       {
+         TileSet = tileSet;
          TextureIndex = textureIndex;
          _isPassable = _passableTextureIndexes.Contains( textureIndex );
       }
 
-      public TileViewModel( TileSaveData saveData )
+      public TileViewModel( TileSet tileSet, TileSaveData saveData )
       {
-         SetTextureIndex( saveData.TextureIndex );
+         TileSet = tileSet;
+         TextureIndex = saveData.TextureIndex;
          _isPassable = saveData.IsPassable;
       }
 

--- a/DragonQuestinoEditor/DragonQuestinoEditor/ViewModels/TileViewModel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/ViewModels/TileViewModel.cs
@@ -20,8 +20,10 @@ namespace DragonQuestinoEditor.ViewModels
          13    // bridge
       ];
 
+      public TileSet TileSet { get; }
+
       private int _textureIndex;
-      public int TextureIndex
+      public int TextureIndexIndex
       {
          get => _textureIndex;
          private set => SetProperty( ref _textureIndex, value );
@@ -46,8 +48,10 @@ namespace DragonQuestinoEditor.ViewModels
       private bool _isSelected = false;
       public bool IsSelected
       {
-         get => _isSelected;
-         set => SetProperty( ref _isSelected, value );
+         TileSet = tileSet;
+         SetIndex( index );
+
+         _isPassable = _passableIndexes.Contains( index );
       }
 
       private bool _isPortalDestination = false;
@@ -87,6 +91,7 @@ namespace DragonQuestinoEditor.ViewModels
       public void SetTextureIndex( int index )
       {
          TextureIndex = index;
+         Image = TileSet.TileBitmaps[index];
          IsPassable = _passableTextureIndexes.Contains( index );
          OnPropertyChanged( nameof( Image ) );
       }


### PR DESCRIPTION
## Overview

This PR makes large changes to the Editor by altering how tiles are edited. This replaces the ListView that presented the tiles, which was super slow. With ~19k tiles, that's a heavy layout phase and this was the source of the performance problems. This is now fixed, and in so doing, the Editor has changed how it works, hopefully for the better.

The ListView is now replaced by a `MapPanel`, a custom panel I wrote that's specialized to efficiently draw tiles. We don't need the general layout systrnem when it's just a glorified tile map. This binds to the existing tile view model collection and draws a big bitmap to prepare them, and then blits just that single bitmap when needed (much faster).

Other notable changes:

- The "map panel" can be panned by holding `Space` and dragging with the left mouse button. This is a common idiom in lots of editors
- The "map panel" can be zoomed with the mouse wheel. This works kind of weird, since zoom factors aren't linear, but I treat them as such. So clicking the mouse wheel once will zoom in twice as far, but zooming out once is _way_ more aggressive. This can probably be "linearized," but I didn't bother.
  - 🐛 Panning is a little off when zoomed in or out. I couldn't quickly figure out how to account for this so I didn't bother
  - 🐛 Zooming occurs from the origin, not where your mouse is, which would feel _way_ more natural
- The "map panel" allows "drawing" with the left mouse button. This will alter whatever tile you're clicking on so you can properly change the map. The "tile picker" is now a ListBox that has a selected item, so you can think of this more like an art program's palette, and you're choosing the "color" you're drawing with (this replaces drag and dropping the tile). Note that you can also drag across tiles to change many at once

Note that changing the map and then saving _does work_, so this Editor truly edits.

## Next steps

Assuming this is all good:

- Fixing those two bugs above would help the UX a lot
- Add a "tool picker" above the "tile picker," so it begins to flesh out a true tool panel, where you can choose to draw or pan. This carves out a space for additional things, such as line tools, rectangle tools, and whatever else we can think up
- Refactor the `MapPanel` to encapsulate the input mode. Right now there are `switch` statements all over that figure out what to do given the state. I think an `InputController` or something would be good, and switching modes would mean swapping out what kind of input controller it is. This means the `MapPanel` input would just work, and delegate all that logic to OCP-style classes
- Add a command pattern to the `MapPanel`. This means we could support `Undo` / `Redo`, since it would track the alterations
- Add a Line tool that can draw a sequence of tiles with a drag. This would be more accurate than painting it yourself, since it would only draw them once you let go, giving you the ability to fine-tune the line
- Add a Rectangle tool that draws a block of tiles
- Add some kind of "Smart Water" tool that knows how to use the right tiles to create an accurate shoreline around the perimeter of water (which would understand bends/corners, etc.)
- A "flood fill" tool might be kinda fun