### PR TITLE
Refactored a bunch of stuff

### DIFF
--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -6,7 +6,7 @@
 
 internal void Game_TicOverworld( Game_t* game );
 internal void Game_TicTileMapTransition( Game_t* game );
-internal void Game_HandleInput( Game_t* game );
+internal void Game_HandleOverworldInput( Game_t* game );
 internal void Game_UpdateTileMapViewport( Game_t* game );
 internal void Game_Draw( Game_t* game );
 internal void Game_DrawTileMap( Game_t* game );
@@ -48,6 +48,8 @@ void Game_Init( Game_t* game, uint16_t* screenBuffer )
 
 void Game_Tic( Game_t* game )
 {
+   Input_Read( &( game->input ) );
+
    switch ( game->state )
    {
       case GameState_Overworld:
@@ -79,8 +81,7 @@ void Game_PlayerSteppedOnTile( Game_t* game, uint32_t tileIndex )
 
 internal void Game_TicOverworld( Game_t* game )
 {
-   Input_Read( &( game->input ) );
-   Game_HandleInput( game );
+   Game_HandleOverworldInput( game );
    Physics_Tic( game );
    Sprite_Tic( &( game->player.sprite ) );
    Game_UpdateTileMapViewport( game );
@@ -93,8 +94,6 @@ internal void Game_TicTileMapTransition( Game_t* game )
 
    if ( game->swapPortal )
    {
-      game->tileMapSwapSecondsElapsed = 0.0f;
-
       destinationTileIndex = game->swapPortal->destinationTileIndex;
       arrivalDirection = game->swapPortal->arrivalDirection;
 
@@ -105,6 +104,7 @@ internal void Game_TicTileMapTransition( Game_t* game )
       game->player.sprite.position.y = (float)( ( int32_t )( TILE_SIZE * ( destinationTileIndex / game->tileMap.tilesX ) ) - game->player.spriteOffset.y ) - COLLISION_THETA;
       game->player.tileIndex = destinationTileIndex;
       game->player.maxVelocity = TileMap_GetWalkSpeedForTileIndex( &( game->tileMap ), destinationTileIndex );
+      game->tileMapSwapSecondsElapsed = 0.0f;
       game->swapPortal = 0;
 
       Sprite_SetDirection( &( game->player.sprite ), arrivalDirection );
@@ -121,7 +121,7 @@ internal void Game_TicTileMapTransition( Game_t* game )
    }
 }
 
-internal void Game_HandleInput( Game_t* game )
+internal void Game_HandleOverworldInput( Game_t* game )
 {
    Player_t* player = &( game->player );
    ActiveSprite_t* playerSprite = &( game->player.sprite );

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -193,8 +193,6 @@ internal void Game_HandleOverworldInput( Game_t* game )
 
 internal void Game_Draw( Game_t* game )
 {
-   uint32_t wipePaletteIndex;
-
    switch ( game->state )
    {
       case GameState_Overworld:
@@ -203,10 +201,7 @@ internal void Game_Draw( Game_t* game )
          Game_DrawPlayer( game );
          break;
       case GameState_TileMapTransition:
-         if ( Screen_GetPaletteIndexForColor( &( game->screen ), 0, &wipePaletteIndex ) )
-         {
-            Screen_Wipe( &( game->screen ), wipePaletteIndex );
-         }
+         Screen_WipeColor( &( game->screen ), COLOR_BLACK );
          break;
    }
 }

--- a/DragonQuestino/game.h
+++ b/DragonQuestino/game.h
@@ -22,7 +22,6 @@ typedef struct Game_t
 
    Vector4i32_t tileMapViewport;
 
-   Bool_t isSwappingTileMap;
    TilePortal_t* swapPortal;
    float tileMapSwapSecondsElapsed;
 }

--- a/DragonQuestino/game.h
+++ b/DragonQuestino/game.h
@@ -9,7 +9,6 @@
 #include "clock.h"
 #include "input.h"
 #include "player.h"
-#include "vector.h"
 
 typedef struct Game_t
 {
@@ -19,8 +18,6 @@ typedef struct Game_t
    Input_t input;
    GameState_t state;
    Player_t player;
-
-   Vector4i32_t tileMapViewport;
 
    TilePortal_t* swapPortal;
    float tileMapSwapSecondsElapsed;

--- a/DragonQuestino/screen.c
+++ b/DragonQuestino/screen.c
@@ -234,3 +234,46 @@ internal int8_t Screen_GetCharIndexFromChar( const char c )
    }
 }
 
+void Screen_DrawMemorySection( Screen_t* screen, uint8_t* memory, uint32_t stride,
+                               uint32_t tx, uint32_t ty, uint32_t tw, uint32_t th,
+                               uint32_t sx, uint32_t sy, Bool_t transparency )
+{
+   uint32_t x, y;
+   uint8_t* textureBufferPos = memory + ( ty * stride ) + tx;
+   uint16_t* screenBufferPos = screen->buffer + ( sy * SCREEN_WIDTH ) + sx;
+
+   if ( transparency )
+   {
+      for ( y = 0; y < th; y++ )
+      {
+         for ( x = 0; x < tw; x++ )
+         {
+            if ( *textureBufferPos != TRANSPARENT_COLOR_INDEX )
+            {
+               *screenBufferPos = screen->palette[*textureBufferPos];
+            }
+
+            textureBufferPos++;
+            screenBufferPos++;
+         }
+
+         textureBufferPos += tx + ( stride - ( tx + tw ) );
+         screenBufferPos += ( SCREEN_WIDTH - tw );
+      }
+   }
+   else
+   {
+      for ( y = 0; y < th; y++ )
+      {
+         for ( x = 0; x < tw; x++ )
+         {
+            *screenBufferPos = screen->palette[*textureBufferPos];
+            textureBufferPos++;
+            screenBufferPos++;
+         }
+
+         textureBufferPos += tx + ( stride - ( tx + tw ) );
+         screenBufferPos += ( SCREEN_WIDTH - tw );
+      }
+   }
+}

--- a/DragonQuestino/screen.c
+++ b/DragonQuestino/screen.c
@@ -25,7 +25,7 @@ Bool_t Screen_GetPaletteIndexForColor( Screen_t* screen, uint16_t color, uint32_
    return False;
 }
 
-void Screen_Wipe( Screen_t* screen, uint32_t paletteIndex )
+void Screen_WipeFromPalette( Screen_t* screen, uint32_t paletteIndex )
 {
    uint32_t i;
    uint16_t* bufferPos = screen->buffer;
@@ -34,6 +34,16 @@ void Screen_Wipe( Screen_t* screen, uint32_t paletteIndex )
    {
       *bufferPos = screen->palette[paletteIndex];
       bufferPos++;
+   }
+}
+
+void Screen_WipeColor( Screen_t* screen, uint16_t color )
+{
+   uint32_t paletteIndex;
+
+   if ( Screen_GetPaletteIndexForColor( screen, color, &paletteIndex ) )
+   {
+      Screen_WipeFromPalette( screen, paletteIndex );
    }
 }
 

--- a/DragonQuestino/screen.h
+++ b/DragonQuestino/screen.h
@@ -41,6 +41,9 @@ void Screen_Wipe( Screen_t* screen, uint32_t paletteIndex );
 void Screen_DrawChar( Screen_t* screen, char c, uint32_t x, uint32_t y, uint16_t color );
 void Screen_DrawText( Screen_t* screen, const char* text, uint32_t x, uint32_t y, uint16_t color );
 void Screen_DrawWrappedText( Screen_t* screen, const char* text, uint32_t x, uint32_t y, uint32_t lineChars, uint16_t color );
+void Screen_DrawMemorySection( Screen_t* screen, uint8_t* memory, uint32_t stride,
+                               uint32_t tx, uint32_t ty, uint32_t tw, uint32_t th,
+                               uint32_t sx, uint32_t sy, Bool_t transparency );
 
 // platform-specific
 void Screen_RenderBuffer( Screen_t* screen );

--- a/DragonQuestino/screen.h
+++ b/DragonQuestino/screen.h
@@ -9,6 +9,12 @@
 
 #define PALETTE_COLORS           256
 
+#define COLOR_BLACK              0x0000
+#define COLOR_WHITE              0xFFFF
+#define COLOR_RED                0xF800
+#define COLOR_GREEN              0x07E0
+#define COLOR_BLUE               0x001F
+
 #define TEXT_TILE_COUNT          83
 #define TEXT_TILE_SIZE           8
 
@@ -37,7 +43,8 @@ extern "C" {
 
 void Screen_Init( Screen_t* screen, uint16_t* buffer );
 Bool_t Screen_GetPaletteIndexForColor( Screen_t* screen, uint16_t color, uint32_t* paletteIndex );
-void Screen_Wipe( Screen_t* screen, uint32_t paletteIndex );
+void Screen_WipeFromPalette( Screen_t* screen, uint32_t paletteIndex );
+void Screen_WipeColor( Screen_t* screen, uint16_t color );
 void Screen_DrawChar( Screen_t* screen, char c, uint32_t x, uint32_t y, uint16_t color );
 void Screen_DrawText( Screen_t* screen, const char* text, uint32_t x, uint32_t y, uint16_t color );
 void Screen_DrawWrappedText( Screen_t* screen, const char* text, uint32_t x, uint32_t y, uint32_t lineChars, uint16_t color );

--- a/DragonQuestino/tile_map.c
+++ b/DragonQuestino/tile_map.c
@@ -1,5 +1,39 @@
 #include "tile_map.h"
 
+void TileMap_Init( TileMap_t* tileMap )
+{
+   tileMap->viewport.x = 0;
+   tileMap->viewport.y = 0;
+   tileMap->viewport.w = TILEMAP_VIEWPORT_WIDTH;
+   tileMap->viewport.h = TILEMAP_VIEWPORT_HEIGHT;
+}
+
+void TileMap_UpdateViewport( TileMap_t* tileMap, int32_t anchorX, int32_t anchorY, uint32_t anchorW, uint32_t anchorH )
+{
+   Vector4i32_t* viewport = &( tileMap->viewport );
+
+   viewport->x = anchorX - ( viewport->w / 2 ) + ( anchorW / 2 );
+   viewport->y = anchorY - ( viewport->h / 2 ) + ( anchorH / 2 );
+
+   if ( viewport->x < 0 )
+   {
+      viewport->x = 0;
+   }
+   else if ( ( viewport->x + viewport->w ) > (int32_t)( tileMap->tilesX * TILE_SIZE ) )
+   {
+      viewport->x = ( tileMap->tilesX * TILE_SIZE ) - viewport->w;
+   }
+
+   if ( viewport->y < 0 )
+   {
+      viewport->y = 0;
+   }
+   else if ( ( viewport->y + viewport->h ) > (int32_t)( tileMap->tilesY * TILE_SIZE ) )
+   {
+      viewport->y = ( tileMap->tilesY * TILE_SIZE ) - viewport->h;
+   }
+}
+
 float TileMap_GetWalkSpeedForTileIndex( TileMap_t* tileMap, uint32_t tileIndex )
 {
    uint16_t tile = tileMap->tiles[( ( tileIndex / tileMap->tilesX ) * TILE_COUNT_X ) + ( tileIndex % tileMap->tilesX )];
@@ -38,4 +72,37 @@ TilePortal_t* TileMap_GetPortalForTileIndex( TileMap_t* tileMap, uint32_t index 
    }
 
    return 0;
+}
+
+void TileMap_Draw( TileMap_t* tileMap, Screen_t* screen )
+{
+   uint32_t firstTileX, firstTileY, lastTileX, lastTileY, tileX, tileY, textureIndex, tileOffsetX, tileOffsetY, tileWidth, tileHeight, screenX, screenY;
+   Vector4i32_t* viewport = &( tileMap->viewport );
+
+   firstTileX = viewport->x / TILE_SIZE;
+   firstTileY = viewport->y / TILE_SIZE;
+   lastTileX = ( viewport->x + TILEMAP_VIEWPORT_WIDTH ) / TILE_SIZE;
+   lastTileY = ( viewport->y + TILEMAP_VIEWPORT_HEIGHT ) / TILE_SIZE;
+   tileOffsetX = viewport->x % TILE_SIZE;
+   tileOffsetY = viewport->y % TILE_SIZE;
+
+   for ( tileY = firstTileY, screenY = 0; tileY <= lastTileY; tileY++ )
+   {
+      tileHeight = ( tileY == firstTileY ) ? TILE_SIZE - tileOffsetY : ( tileY == lastTileY ) ? ( viewport->y + TILEMAP_VIEWPORT_HEIGHT ) % TILE_SIZE : TILE_SIZE;
+
+      for ( tileX = firstTileX, screenX = 0; tileX <= lastTileX; tileX++ )
+      {
+         textureIndex = GET_TILETEXTUREINDEX( tileMap->tiles[( tileY * TILE_COUNT_X ) + tileX] );
+         tileWidth = ( tileX == firstTileX ) ? TILE_SIZE - tileOffsetX : ( tileX == lastTileX ) ? ( viewport->x + TILEMAP_VIEWPORT_WIDTH ) % TILE_SIZE : TILE_SIZE;
+
+         Screen_DrawMemorySection( screen, tileMap->textures[textureIndex].memory, TILE_SIZE,
+                                   tileX == firstTileX ? tileOffsetX : 0, tileY == firstTileY ? tileOffsetY : 0,
+                                   tileWidth, tileHeight,
+                                   screenX, screenY, False );
+
+         screenX += tileWidth;
+      }
+
+      screenY += tileHeight;
+   }
 }

--- a/DragonQuestino/tile_map.h
+++ b/DragonQuestino/tile_map.h
@@ -65,6 +65,7 @@ typedef struct TileMap_t
    uint16_t tiles[TILE_COUNT];
    uint32_t tilesX;
    uint32_t tilesY;
+   Vector4i32_t viewport;
 
    TileTexture_t textures[TILE_TEXTURE_COUNT];
 
@@ -83,8 +84,11 @@ TileMap_t;
 extern "C" {
 #endif
 
+void TileMap_Init( TileMap_t* tileMap );
+void TileMap_UpdateViewport( TileMap_t* tileMap, int32_t anchorX, int32_t anchorY, uint32_t anchorW, uint32_t anchorH );
 float TileMap_GetWalkSpeedForTileIndex( TileMap_t* tileMap, uint32_t tileIndex );
 TilePortal_t* TileMap_GetPortalForTileIndex( TileMap_t* tileMap, uint32_t index );
+void TileMap_Draw( TileMap_t* tileMap, Screen_t* screen );
 
 // game_data.c
 void TileMap_LoadTextures( TileMap_t* tileMap );

--- a/DragonQuestinoWinDev/DragonQuestinoWinDev/win_main.c
+++ b/DragonQuestinoWinDev/DragonQuestinoWinDev/win_main.c
@@ -304,7 +304,7 @@ internal void DrawDiagnostics( HDC* dcMem )
    DrawTextA( *dcMem, str, -1, &r, DT_SINGLELINE | DT_NOCLIP );
    r.top += 16;
 
-   sprintf_s( str, STRING_SIZE_DEFAULT, " Map Viewport: %i, %i", g_globals.game.tileMapViewport.x, g_globals.game.tileMapViewport.y );
+   sprintf_s( str, STRING_SIZE_DEFAULT, " Map Viewport: %i, %i", g_globals.game.tileMap.viewport.x, g_globals.game.tileMap.viewport.y );
    DrawTextA( *dcMem, str, -1, &r, DT_SINGLELINE | DT_NOCLIP );
    r.top += 16;
 


### PR DESCRIPTION
## Overview

This is some cleanup I wanted to do before getting into the more nitty-gritty engine stuff, just so we have a nice place to start. Changes include:

- Refactored the drawing code to be more straightforward. The different game states are more separated now and the overworld state doesn't have to check if the tile map is transitioning.
- Got rid of the unnecessary is-tile-map-transitioning boolean, we can just check if a portal is available.
- Moved a bunch of the tile map code from game.c to tile_map.c where it makes more sense to be.
- Moved some screen drawing functions into screen.c where they make more sense to be.
- Shuffled a few function calls around into an order that reads better.

Hopefully these changes make it easier to add new features.