### PR TITLE
Added overworld status bar

### DIFF
--- a/DragonQuestino/battle_stats.h
+++ b/DragonQuestino/battle_stats.h
@@ -1,0 +1,19 @@
+#if !defined( BATTLE_STATS_H )
+#define BATTLE_STATS_H
+
+#include "common.h"
+
+typedef struct BattleStats_t
+{
+   uint8_t hitPoints;
+   uint8_t maxHitPoints;
+   uint8_t magicPoints;
+   uint8_t maxMagicPoints;
+   uint8_t attackPower;
+   uint8_t defensePower;
+   uint8_t agility;
+   uint8_t luck;
+}
+BattleStats_t;
+
+#endif // BATTLE_STATS_H

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -14,6 +14,7 @@ internal void Game_Draw( Game_t* game );
 internal void Game_DrawOverworld( Game_t* game );
 internal void Game_DrawStaticSprites( Game_t* game );
 internal void Game_DrawPlayer( Game_t* game );
+internal void Game_DrawOverworldStatus( Game_t* game );
 
 void Game_Init( Game_t* game, uint16_t* screenBuffer )
 {
@@ -154,11 +155,14 @@ internal void Game_HandleOverworldInput( Game_t* game )
 
    if ( game->input.buttonStates[Button_A].pressed )
    {
+      game->overworldInactivitySeconds = 0.0f;
       Menu_Load( &( game->menu ), MenuId_Overworld );
       Game_ChangeState( game, GameState_Overworld_MainMenu );
    }
    else if ( leftIsDown || upIsDown || rightIsDown || downIsDown )
    {
+      game->overworldInactivitySeconds = 0.0f;
+
       if ( leftIsDown && !rightIsDown )
       {
          player->velocity.x = -( player->maxVelocity );
@@ -267,8 +271,12 @@ internal void Game_HandleMenuInput( Game_t* game )
    }
    else if ( game->input.buttonStates[Button_B].pressed )
    {
-      // TODO: this will depend entirely on which menu is currently open
-      Game_ChangeState( game, GameState_Overworld );
+      switch ( game->state )
+      {
+         case GameState_Overworld_MainMenu:
+            Game_ChangeState( game, GameState_Overworld );
+            break;
+      }
    }
    else
    {
@@ -291,10 +299,12 @@ internal void Game_Draw( Game_t* game )
          break;
       case GameState_Overworld_MainMenu:
          Game_DrawOverworld( game );
+         Game_DrawOverworldStatus( game );
          Menu_Draw( &( game->menu ), &( game->screen ) );
          break;
       case GameState_Overworld_Talk:
          Game_DrawOverworld( game );
+         Game_DrawOverworldStatus( game );
          Menu_Draw( &( game->menu ), &( game->screen ) );
          ScrollingDialog_Draw( &( game->scrollingDialog ), &( game->screen ) );
          break;
@@ -309,6 +319,11 @@ internal void Game_DrawOverworld( Game_t* game )
    TileMap_Draw( &( game->tileMap ), &( game->screen ) );
    Game_DrawStaticSprites( game );
    Game_DrawPlayer( game );
+
+   if ( game->overworldInactivitySeconds > OVERWORLD_INACTIVE_STATUS_SECONDS )
+   {
+      Game_DrawOverworldStatus( game );
+   }
 }
 
 internal void Game_DrawStaticSprites( Game_t* game )
@@ -355,4 +370,10 @@ internal void Game_DrawPlayer( Game_t* game )
    uint32_t syu = ( sy < 0 ) ? 0 : sy;
 
    Screen_DrawMemorySection( &( game->screen ), sprite->textures[textureIndex].memory, SPRITE_TEXTURE_SIZE, tx, ty, tw, th, sxu, syu, True );
+}
+
+internal void Game_DrawOverworldStatus( Game_t* game )
+{
+   // TODO: draw actual stats
+   Screen_DrawTextWindow( &( game->screen ), 16, 16, 8, 12, COLOR_WHITE );
 }

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -374,6 +374,23 @@ internal void Game_DrawPlayer( Game_t* game )
 
 internal void Game_DrawOverworldStatus( Game_t* game )
 {
-   // TODO: draw actual stats
-   Screen_DrawTextWindow( &( game->screen ), 16, 16, 8, 12, COLOR_WHITE );
+   uint8_t lvl = Player_GetLevel( &( game->player ) );
+   char line[8];
+
+   Screen_DrawTextWindow( &( game->screen ), 16, 16, 8, 11, COLOR_WHITE );
+
+   sprintf( line, lvl < 10 ? "LV   %u" : "LV  %u", lvl);   
+   Screen_DrawText( &( game->screen ), line, 24, 24, COLOR_WHITE );
+
+   sprintf( line, game->player.stats.hitPoints < 10 ? "HP   %u" : game->player.stats.hitPoints < 100 ? "HP  %u" : "HP %u", game->player.stats.hitPoints );
+   Screen_DrawText( &( game->screen ), line, 24, 40, COLOR_WHITE );
+
+   sprintf( line, game->player.stats.magicPoints < 10 ? "MP   %u" : game->player.stats.magicPoints < 100 ? "MP  %u" : "MP %u", game->player.stats.magicPoints );
+   Screen_DrawText( &( game->screen ), line, 24, 56, COLOR_WHITE );
+
+   sprintf( line, game->player.gold < 10 ? "G    %u" : game->player.gold < 100 ? "G   %u" : game->player.gold < 1000 ? "G  %u" : game->player.gold < 10000 ? "G %u" : "G%u", game->player.gold );
+   Screen_DrawText( &( game->screen ), line, 24, 72, COLOR_WHITE );
+
+   sprintf( line, game->player.experience < 10 ? "E    %u" : game->player.experience < 100 ? "G   %u" : game->player.experience < 1000 ? "G  %u" : game->player.experience < 10000 ? "G %u" : "G%u", game->player.experience );
+   Screen_DrawText( &( game->screen ), line, 24, 88, COLOR_WHITE );
 }

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -377,20 +377,20 @@ internal void Game_DrawOverworldStatus( Game_t* game )
    uint8_t lvl = Player_GetLevel( &( game->player ) );
    char line[8];
 
-   Screen_DrawTextWindow( &( game->screen ), 16, 16, 8, 11, COLOR_WHITE );
+   Screen_DrawTextWindow( &( game->screen ), 16, 16, 9, 11, COLOR_WHITE );
 
-   sprintf( line, lvl < 10 ? "LV   %u" : "LV  %u", lvl);   
+   sprintf( line, lvl < 10 ? "LV    %u" : "LV   %u", lvl);   
    Screen_DrawText( &( game->screen ), line, 24, 24, COLOR_WHITE );
 
-   sprintf( line, game->player.stats.hitPoints < 10 ? "HP   %u" : game->player.stats.hitPoints < 100 ? "HP  %u" : "HP %u", game->player.stats.hitPoints );
+   sprintf( line, game->player.stats.hitPoints < 10 ? "HP    %u" : game->player.stats.hitPoints < 100 ? "HP   %u" : "HP  %u", game->player.stats.hitPoints );
    Screen_DrawText( &( game->screen ), line, 24, 40, COLOR_WHITE );
 
-   sprintf( line, game->player.stats.magicPoints < 10 ? "MP   %u" : game->player.stats.magicPoints < 100 ? "MP  %u" : "MP %u", game->player.stats.magicPoints );
+   sprintf( line, game->player.stats.magicPoints < 10 ? "MP    %u" : game->player.stats.magicPoints < 100 ? "MP   %u" : "MP  %u", game->player.stats.magicPoints );
    Screen_DrawText( &( game->screen ), line, 24, 56, COLOR_WHITE );
 
-   sprintf( line, game->player.gold < 10 ? "G    %u" : game->player.gold < 100 ? "G   %u" : game->player.gold < 1000 ? "G  %u" : game->player.gold < 10000 ? "G %u" : "G%u", game->player.gold );
+   sprintf( line, game->player.gold < 10 ? "G     %u" : game->player.gold < 100 ? "G    %u" : game->player.gold < 1000 ? "G   %u" : game->player.gold < 10000 ? "G  %u" : "G %u", game->player.gold );
    Screen_DrawText( &( game->screen ), line, 24, 72, COLOR_WHITE );
 
-   sprintf( line, game->player.experience < 10 ? "E    %u" : game->player.experience < 100 ? "G   %u" : game->player.experience < 1000 ? "G  %u" : game->player.experience < 10000 ? "G %u" : "G%u", game->player.experience );
+   sprintf( line, game->player.experience < 10 ? "E     %u" : game->player.experience < 100 ? "G    %u" : game->player.experience < 1000 ? "G   %u" : game->player.experience < 10000 ? "G  %u" : "G %u", game->player.experience );
    Screen_DrawText( &( game->screen ), line, 24, 88, COLOR_WHITE );
 }

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -375,22 +375,26 @@ internal void Game_DrawPlayer( Game_t* game )
 internal void Game_DrawOverworldStatus( Game_t* game )
 {
    uint8_t lvl = Player_GetLevel( &( game->player ) );
+   uint32_t memSize;
    char line[9];
 
-   Screen_DrawTextWindowWithTitle( &( game->screen ), 16, 16, 10, 12, game->player.name, COLOR_WHITE );
+   memSize = MATH_MINU32( (uint32_t)( strlen( game->player.name ) ), 4 );
+   memcpy( line, game->player.name, sizeof( char ) * memSize );
+   line[memSize] = '\0';
+   Screen_DrawTextWindowWithTitle( &( game->screen ), 16, 16, 8, 12, line, COLOR_WHITE );
 
-   sprintf( line, lvl < 10 ? "LV     %u" : "LV    %u", lvl);
+   sprintf( line, lvl < 10 ? "LV   %u" : "LV  %u", lvl);
    Screen_DrawText( &( game->screen ), line, 24, 32, COLOR_WHITE );
 
-   sprintf( line, game->player.stats.hitPoints < 10 ? "HP     %u" : game->player.stats.hitPoints < 100 ? "HP    %u" : "HP   %u", game->player.stats.hitPoints );
+   sprintf( line, game->player.stats.hitPoints < 10 ? "HP   %u" : game->player.stats.hitPoints < 100 ? "HP  %u" : "HP %u", game->player.stats.hitPoints );
    Screen_DrawText( &( game->screen ), line, 24, 48, COLOR_WHITE );
 
-   sprintf( line, game->player.stats.magicPoints < 10 ? "MP     %u" : game->player.stats.magicPoints < 100 ? "MP    %u" : "MP   %u", game->player.stats.magicPoints );
+   sprintf( line, game->player.stats.magicPoints < 10 ? "MP   %u" : game->player.stats.magicPoints < 100 ? "MP  %u" : "MP %u", game->player.stats.magicPoints );
    Screen_DrawText( &( game->screen ), line, 24, 64, COLOR_WHITE );
 
-   sprintf( line, game->player.gold < 10 ? "G      %u" : game->player.gold < 100 ? "G     %u" : game->player.gold < 1000 ? "G    %u" : game->player.gold < 10000 ? "G   %u" : "G  %u", game->player.gold );
+   sprintf( line, game->player.gold < 10 ? "G    %u" : game->player.gold < 100 ? "G   %u" : game->player.gold < 1000 ? "G  %u" : game->player.gold < 10000 ? "G %u" : "G%u", game->player.gold );
    Screen_DrawText( &( game->screen ), line, 24, 80, COLOR_WHITE );
 
-   sprintf( line, game->player.experience < 10 ? "E      %u" : game->player.experience < 100 ? "G     %u" : game->player.experience < 1000 ? "G    %u" : game->player.experience < 10000 ? "G   %u" : "G  %u", game->player.experience );
+   sprintf( line, game->player.experience < 10 ? "E    %u" : game->player.experience < 100 ? "E   %u" : game->player.experience < 1000 ? "E  %u" : game->player.experience < 10000 ? "E %u" : "E%u", game->player.experience );
    Screen_DrawText( &( game->screen ), line, 24, 96, COLOR_WHITE );
 }

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -375,22 +375,22 @@ internal void Game_DrawPlayer( Game_t* game )
 internal void Game_DrawOverworldStatus( Game_t* game )
 {
    uint8_t lvl = Player_GetLevel( &( game->player ) );
-   char line[8];
+   char line[9];
 
-   Screen_DrawTextWindow( &( game->screen ), 16, 16, 9, 11, COLOR_WHITE );
+   Screen_DrawTextWindowWithTitle( &( game->screen ), 16, 16, 10, 12, game->player.name, COLOR_WHITE );
 
-   sprintf( line, lvl < 10 ? "LV    %u" : "LV   %u", lvl);   
-   Screen_DrawText( &( game->screen ), line, 24, 24, COLOR_WHITE );
+   sprintf( line, lvl < 10 ? "LV     %u" : "LV    %u", lvl);
+   Screen_DrawText( &( game->screen ), line, 24, 32, COLOR_WHITE );
 
-   sprintf( line, game->player.stats.hitPoints < 10 ? "HP    %u" : game->player.stats.hitPoints < 100 ? "HP   %u" : "HP  %u", game->player.stats.hitPoints );
-   Screen_DrawText( &( game->screen ), line, 24, 40, COLOR_WHITE );
+   sprintf( line, game->player.stats.hitPoints < 10 ? "HP     %u" : game->player.stats.hitPoints < 100 ? "HP    %u" : "HP   %u", game->player.stats.hitPoints );
+   Screen_DrawText( &( game->screen ), line, 24, 48, COLOR_WHITE );
 
-   sprintf( line, game->player.stats.magicPoints < 10 ? "MP    %u" : game->player.stats.magicPoints < 100 ? "MP   %u" : "MP  %u", game->player.stats.magicPoints );
-   Screen_DrawText( &( game->screen ), line, 24, 56, COLOR_WHITE );
+   sprintf( line, game->player.stats.magicPoints < 10 ? "MP     %u" : game->player.stats.magicPoints < 100 ? "MP    %u" : "MP   %u", game->player.stats.magicPoints );
+   Screen_DrawText( &( game->screen ), line, 24, 64, COLOR_WHITE );
 
-   sprintf( line, game->player.gold < 10 ? "G     %u" : game->player.gold < 100 ? "G    %u" : game->player.gold < 1000 ? "G   %u" : game->player.gold < 10000 ? "G  %u" : "G %u", game->player.gold );
-   Screen_DrawText( &( game->screen ), line, 24, 72, COLOR_WHITE );
+   sprintf( line, game->player.gold < 10 ? "G      %u" : game->player.gold < 100 ? "G     %u" : game->player.gold < 1000 ? "G    %u" : game->player.gold < 10000 ? "G   %u" : "G  %u", game->player.gold );
+   Screen_DrawText( &( game->screen ), line, 24, 80, COLOR_WHITE );
 
-   sprintf( line, game->player.experience < 10 ? "E     %u" : game->player.experience < 100 ? "G    %u" : game->player.experience < 1000 ? "G   %u" : game->player.experience < 10000 ? "G  %u" : "G %u", game->player.experience );
-   Screen_DrawText( &( game->screen ), line, 24, 88, COLOR_WHITE );
+   sprintf( line, game->player.experience < 10 ? "E      %u" : game->player.experience < 100 ? "G     %u" : game->player.experience < 1000 ? "G    %u" : game->player.experience < 10000 ? "G   %u" : "G  %u", game->player.experience );
+   Screen_DrawText( &( game->screen ), line, 24, 96, COLOR_WHITE );
 }

--- a/DragonQuestino/game.h
+++ b/DragonQuestino/game.h
@@ -23,6 +23,8 @@ typedef struct Game_t
    Menu_t menu;
    ScrollingDialog_t scrollingDialog;
 
+   float overworldInactivitySeconds;
+
    TilePortal_t* swapPortal;
    float tileMapSwapSecondsElapsed;
 }
@@ -33,6 +35,7 @@ extern "C" {
 #endif
 
 void Game_Init( Game_t* game, uint16_t* screenBuffer );
+void Game_ChangeState( Game_t* game, GameState_t newState );
 void Game_Tic( Game_t* game );
 void Game_PlayerSteppedOnTile( Game_t* game, uint32_t tileIndex );
 

--- a/DragonQuestino/game.h
+++ b/DragonQuestino/game.h
@@ -1,7 +1,8 @@
 #if !defined( GAME_H )
 #define GAME_H
 
-#define TILEMAP_SWAP_SECONDS 0.4f
+#define TILEMAP_SWAP_SECONDS                 0.4f
+#define OVERWORLD_INACTIVE_STATUS_SECONDS    1.0f
 
 #include "common.h"
 #include "screen.h"

--- a/DragonQuestino/math.h
+++ b/DragonQuestino/math.h
@@ -3,6 +3,9 @@
 
 #include "common.h"
 
+#define MATH_MINU32( l, r ) ( ( l ) < ( r ) ? ( l ) : ( r ) )
+#define MATH_MAXU32( l, r ) ( ( l ) > ( r ) ? ( l ) : ( r ) )
+
 #if defined( __cplusplus )
 extern "C" {
 #endif

--- a/DragonQuestino/menu.c
+++ b/DragonQuestino/menu.c
@@ -135,7 +135,7 @@ internal void Menu_LoadOverworld( Menu_t* menu )
    menu->itemsPerColumn = 3;
    menu->selectedIndex = 0;
 
-   menu->position.x = 96;
+   menu->position.x = 112;
    menu->position.y = 16;
    menu->borderSize.x = 16;
    menu->borderSize.y = 8;

--- a/DragonQuestino/menu.c
+++ b/DragonQuestino/menu.c
@@ -135,7 +135,7 @@ internal void Menu_LoadOverworld( Menu_t* menu )
    menu->itemsPerColumn = 3;
    menu->selectedIndex = 0;
 
-   menu->position.x = 112;
+   menu->position.x = 96;
    menu->position.y = 16;
    menu->borderSize.x = 16;
    menu->borderSize.y = 8;

--- a/DragonQuestino/player.c
+++ b/DragonQuestino/player.c
@@ -14,4 +14,50 @@ void Player_Init( Player_t* player )
    player->spriteOffset.x = -2;
    player->spriteOffset.y = -4;
    player->sprite.direction = Direction_Down;
+
+   player->stats.hitPoints = 12;
+   player->stats.maxHitPoints = 12;
+   player->stats.magicPoints = 0;
+   player->stats.maxMagicPoints = 0;
+   player->stats.attackPower = 2;
+   player->stats.defensePower = 2;
+   player->stats.agility = 2;
+   player->stats.luck = 2;
+
+   player->experience = 0;
+   player->gold = 0;
+}
+
+uint8_t Player_GetLevel( Player_t* player )
+{
+   if ( player->experience < 7 ) { return 1; }
+   else if ( player->experience < 23 ) { return 2; }
+   else if ( player->experience < 47 ) { return 3; }
+   else if ( player->experience < 110 ) { return 4; }
+   else if ( player->experience < 220 ) { return 5; }
+   else if ( player->experience < 450 ) { return 6; }
+   else if ( player->experience < 800 ) { return 7; }
+   else if ( player->experience < 1300 ) { return 8; }
+   else if ( player->experience < 2000 ) { return 9; }
+   else if ( player->experience < 2900 ) { return 10; }
+   else if ( player->experience < 4000 ) { return 11; }
+   else if ( player->experience < 5500 ) { return 12; }
+   else if ( player->experience < 7500 ) { return 13; }
+   else if ( player->experience < 10000 ) { return 14; }
+   else if ( player->experience < 13000 ) { return 15; }
+   else if ( player->experience < 16000 ) { return 16; }
+   else if ( player->experience < 19000 ) { return 17; }
+   else if ( player->experience < 22000 ) { return 18; }
+   else if ( player->experience < 26000 ) { return 19; }
+   else if ( player->experience < 30000 ) { return 20; }
+   else if ( player->experience < 34000 ) { return 21; }
+   else if ( player->experience < 38000 ) { return 22; }
+   else if ( player->experience < 42000 ) { return 23; }
+   else if ( player->experience < 46000 ) { return 24; }
+   else if ( player->experience < 50000 ) { return 25; }
+   else if ( player->experience < 54000 ) { return 26; }
+   else if ( player->experience < 58000 ) { return 27; }
+   else if ( player->experience < 62000 ) { return 28; }
+   else if ( player->experience < 65535 ) { return 29; }
+   else { return 30; }
 }

--- a/DragonQuestino/player.c
+++ b/DragonQuestino/player.c
@@ -15,6 +15,8 @@ void Player_Init( Player_t* player )
    player->spriteOffset.y = -4;
    player->sprite.direction = Direction_Down;
 
+   strcpy( player->name, "TestMan" );
+
    player->stats.hitPoints = 12;
    player->stats.maxHitPoints = 12;
    player->stats.magicPoints = 0;

--- a/DragonQuestino/player.h
+++ b/DragonQuestino/player.h
@@ -3,6 +3,7 @@
 
 #include "common.h"
 #include "sprite.h"
+#include "battle_stats.h"
 
 typedef struct Player_t
 {
@@ -13,6 +14,10 @@ typedef struct Player_t
    Vector2u32_t hitBoxSize;
 
    uint32_t tileIndex;
+
+   BattleStats_t stats;
+   uint16_t experience;
+   uint16_t gold;
 }
 Player_t;
 
@@ -21,6 +26,7 @@ extern "C" {
 #endif
 
 void Player_Init( Player_t* player );
+uint8_t Player_GetLevel( Player_t* player );
 
 #if defined( __cplusplus )
 }

--- a/DragonQuestino/player.h
+++ b/DragonQuestino/player.h
@@ -15,6 +15,7 @@ typedef struct Player_t
 
    uint32_t tileIndex;
 
+   char name[9];
    BattleStats_t stats;
    uint16_t experience;
    uint16_t gold;

--- a/DragonQuestino/screen.c
+++ b/DragonQuestino/screen.c
@@ -302,9 +302,5 @@ void Screen_DrawTextWindow( Screen_t* screen, uint32_t x, uint32_t y, uint32_t w
 void Screen_DrawTextWindowWithTitle( Screen_t* screen, uint32_t x, uint32_t y, uint32_t w, uint32_t h, const char* title, uint16_t color )
 {
    Screen_DrawTextWindow( screen, x, y, w, h, color );
-   // MUFFINS: I believe this is drawing at the wrong spot....
-   //
-   // - figure out which character of the line to start on
-   uint32_t startIndex = ( w - (uint32_t)( strlen( title ) ) ) / 2;
-   Screen_DrawText( screen, title, x + ( startIndex * TEXT_TILE_SIZE ), y, color );
+   Screen_DrawText( screen, title, x + ( ( ( w - (uint32_t)( strlen( title ) ) ) / 2 ) * TEXT_TILE_SIZE ), y, color );
 }

--- a/DragonQuestino/screen.c
+++ b/DragonQuestino/screen.c
@@ -302,5 +302,9 @@ void Screen_DrawTextWindow( Screen_t* screen, uint32_t x, uint32_t y, uint32_t w
 void Screen_DrawTextWindowWithTitle( Screen_t* screen, uint32_t x, uint32_t y, uint32_t w, uint32_t h, const char* title, uint16_t color )
 {
    Screen_DrawTextWindow( screen, x, y, w, h, color );
-   Screen_DrawText( screen, title, x + ( ( w / 2 ) + ( (uint32_t)( strlen( title ) ) / 2 ) * TEXT_TILE_SIZE ), y, color );
+   // MUFFINS: I believe this is drawing at the wrong spot....
+   //
+   // - figure out which character of the line to start on
+   uint32_t startIndex = ( w - (uint32_t)( strlen( title ) ) ) / 2;
+   Screen_DrawText( screen, title, x + ( startIndex * TEXT_TILE_SIZE ), y, color );
 }

--- a/DragonQuestinoWinDev/DragonQuestinoWinDev/DragonQuestinoWinDev.vcxproj
+++ b/DragonQuestinoWinDev/DragonQuestinoWinDev/DragonQuestinoWinDev.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\DragonQuestino\battle_stats.h" />
     <ClInclude Include="..\..\DragonQuestino\clock.h" />
     <ClInclude Include="..\..\DragonQuestino\common.h" />
     <ClInclude Include="..\..\DragonQuestino\enums.h" />

--- a/DragonQuestinoWinDev/DragonQuestinoWinDev/win_main.c
+++ b/DragonQuestinoWinDev/DragonQuestinoWinDev/win_main.c
@@ -97,7 +97,7 @@ int CALLBACK WinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance
 
    Game_Init( &( g_globals.game ), g_globals.screenBuffer.memory16 );
    g_globals.shutdown = False;
-   g_debugFlags.showDiagnostics = True;
+   g_debugFlags.showDiagnostics = False;
    g_debugFlags.noClip = False;
    g_debugFlags.fastWalk = False;
 


### PR DESCRIPTION
## Overview

After a little testing, I decided to make it the same size as the original and only show the first four letters of the player's name, that way it covers less real estate. This should show up after being "inactive" on the overworld for 1 second.