### PR TITLE
Added the Rainbow Bridge when using Rainbow Drop

### DIFF
--- a/DragonQuestino/enums.h
+++ b/DragonQuestino/enums.h
@@ -108,6 +108,7 @@ typedef enum DialogMessageId_t
    DialogMessageId_Use_SilverHarp,
    DialogMessageId_Use_GwaelynsLoveCantUse,
    DialogMessageId_Use_GwaelynsLove,
+   DialogMessageId_Use_RainbowDropCantUse,
    DialogMessageId_Use_RainbowDrop,
    DialogMessageId_Use_CursedBelt,
 

--- a/DragonQuestino/enums.h
+++ b/DragonQuestino/enums.h
@@ -22,6 +22,7 @@ typedef enum GameState_t
    GameState_Overworld_MainMenu,
    GameState_Overworld_ItemMenu,
    GameState_Overworld_ScrollingDialog,
+   GameState_Overworld_RainbowBridgeAnimation,
    GameState_TileMapTransition,
 
    GameState_Count

--- a/DragonQuestino/game.h
+++ b/DragonQuestino/game.h
@@ -14,6 +14,7 @@
 #define OVERWORLD_INACTIVE_STATUS_SECONDS    1.0f
 #define OVERWORLD_LIGHTING_FRAME_SECONDS     0.1f
 #define OVERWORLD_WASH_TOTAL_SECONDS         0.2f
+#define RAINBOW_BRIDGE_TOTAL_SECONDS         5.0f
 #define COLLISION_THETA                      0.001f
 
 typedef struct Game_t
@@ -34,6 +35,7 @@ typedef struct Game_t
    float tileMapSwapSecondsElapsed;
 
    float lightingSecondsElapsed;
+   float rainbowBridgeSecondsElapsed;
 }
 Game_t;
 

--- a/DragonQuestino/game_data.c
+++ b/DragonQuestino/game_data.c
@@ -11836,6 +11836,12 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t index )
          tiles32[494] = 0x01060128;
          break;
    }
+
+   if ( index == TILEMAP_OVERWORLD_ID && tileMap->usedRainbowDrop )
+   {
+      TILE_SET_TEXTUREINDEX( tileMap->tiles[TILEMAP_RAINBOWBRIDGE_INDEX], 13 );
+      TILE_SET_PASSABLE( tileMap->tiles[TILEMAP_RAINBOWBRIDGE_INDEX], True );
+   }
 }
 
 void Sprite_LoadPlayer( ActiveSprite_t* sprite )

--- a/DragonQuestino/game_data.c
+++ b/DragonQuestino/game_data.c
@@ -7,6 +7,8 @@ void Screen_LoadPalette( Screen_t* screen )
 {
    uint16_t i;
 
+   screen->paletteColorCount = 13;
+
    for ( i = 0; i < 256; i++ ) { screen->palette[i] = 0; }
 
    screen->palette[0] = 0x9720;

--- a/DragonQuestino/game_input.c
+++ b/DragonQuestino/game_input.c
@@ -131,14 +131,13 @@ internal void Game_HandleOverworldScrollingDialogInput( Game_t* game )
       {
          if ( game->scrollingDialog.messageId == DialogMessageId_Use_RainbowDrop )
          {
-            // TODO: change the state to rainbow bridge animation, then do this after the animation is done
-            PLAYER_TOGGLE_HASRAINBOWDROP( game->player.items );
-            game->tileMap.usedRainbowDrop = True;
-            TILE_SET_TEXTUREINDEX( game->tileMap.tiles[TILEMAP_RAINBOWBRIDGE_INDEX], 13 );
-            TILE_SET_PASSABLE( game->tileMap.tiles[TILEMAP_RAINBOWBRIDGE_INDEX], True );
+            Screen_BackupPalette( &( game->screen ) );
+            Game_ChangeState( game, GameState_Overworld_RainbowBridgeAnimation );
          }
-
-         Game_ChangeState( game, GameState_Overworld_Washing );
+         else
+         {
+            Game_ChangeState( game, GameState_Overworld_Washing );
+         }
       }
    }
    else if ( game->input.buttonStates[Button_A].pressed || game->input.buttonStates[Button_B].pressed )

--- a/DragonQuestino/game_input.c
+++ b/DragonQuestino/game_input.c
@@ -129,6 +129,15 @@ internal void Game_HandleOverworldScrollingDialogInput( Game_t* game )
    {
       if ( Input_AnyButtonPressed( &( game->input ) ) )
       {
+         if ( game->scrollingDialog.messageId == DialogMessageId_Use_RainbowDrop )
+         {
+            // TODO: change the state to rainbow bridge animation, then do this after the animation is done
+            PLAYER_TOGGLE_HASRAINBOWDROP( game->player.items );
+            game->tileMap.usedRainbowDrop = True;
+            TILE_SET_TEXTUREINDEX( game->tileMap.tiles[TILEMAP_RAINBOWBRIDGE_INDEX], 13 );
+            TILE_SET_PASSABLE( game->tileMap.tiles[TILEMAP_RAINBOWBRIDGE_INDEX], True );
+         }
+
          Game_ChangeState( game, GameState_Overworld_Washing );
       }
    }

--- a/DragonQuestino/game_items.c
+++ b/DragonQuestino/game_items.c
@@ -90,8 +90,18 @@ void Game_UseGwaelynsLove( Game_t* game )
 
 void Game_UseRainbowDrop( Game_t* game )
 {
-   Game_ChangeState( game, GameState_Overworld_ScrollingDialog );
-   ScrollingDialog_Load( &( game->scrollingDialog ), ScrollingDialogType_Overworld, DialogMessageId_Use_RainbowDrop );
+   if ( game->tileMap.id == TILEMAP_OVERWORLD_ID &&
+        game->player.tileIndex == ( TILEMAP_RAINBOWBRIDGE_INDEX + 1 ) &&
+        game->player.sprite.direction == Direction_Left )
+   {
+      Game_ChangeState( game, GameState_Overworld_ScrollingDialog );
+      ScrollingDialog_Load( &( game->scrollingDialog ), ScrollingDialogType_Overworld, DialogMessageId_Use_RainbowDrop );
+   }
+   else
+   {
+      Game_ChangeState( game, GameState_Overworld_ScrollingDialog );
+      ScrollingDialog_Load( &( game->scrollingDialog ), ScrollingDialogType_Overworld, DialogMessageId_Use_RainbowDropCantUse );
+   }
 }
 
 void Game_UseCursedBelt( Game_t* game )

--- a/DragonQuestino/game_physics.c
+++ b/DragonQuestino/game_physics.c
@@ -56,7 +56,7 @@ void Game_TicPhysics( Game_t* game )
                tileIndex = col + ( row * TILE_COUNT_X );
                tile = game->tileMap.tiles[tileIndex];
 
-               if ( !GET_TILEPASSABLE( tile ) )
+               if ( !TILE_GET_PASSABLE( tile ) )
                {
                   newPos.x = (float)( ( ( col + 1 ) * TILE_SIZE ) );
                   break;
@@ -73,7 +73,7 @@ void Game_TicPhysics( Game_t* game )
                tileIndex = col + ( row * TILE_COUNT_X );
                tile = game->tileMap.tiles[tileIndex];
 
-               if ( !GET_TILEPASSABLE( tile ) )
+               if ( !TILE_GET_PASSABLE( tile ) )
                {
                   newPos.x = ( col * TILE_SIZE ) - player->hitBoxSize.x - COLLISION_THETA;
                   break;
@@ -98,7 +98,7 @@ void Game_TicPhysics( Game_t* game )
                tileIndex = col + ( row * TILE_COUNT_X );
                tile = game->tileMap.tiles[tileIndex];
 
-               if ( !GET_TILEPASSABLE( tile ) )
+               if ( !TILE_GET_PASSABLE( tile ) )
                {
                   newPos.y = (float)( ( ( row + 1 ) * TILE_SIZE ) );
                   break;
@@ -115,7 +115,7 @@ void Game_TicPhysics( Game_t* game )
                tileIndex = col + ( row * TILE_COUNT_X );
                tile = game->tileMap.tiles[tileIndex];
 
-               if ( !GET_TILEPASSABLE( tile ) )
+               if ( !TILE_GET_PASSABLE( tile ) )
                {
                   newPos.y = ( row * TILE_SIZE ) - player->hitBoxSize.y - COLLISION_THETA;
                   break;

--- a/DragonQuestino/game_render.c
+++ b/DragonQuestino/game_render.c
@@ -10,6 +10,7 @@ void Game_Draw( Game_t* game )
    {
       case GameState_Overworld:
       case GameState_Overworld_Washing:
+      case GameState_Overworld_RainbowBridgeAnimation:
          Game_DrawOverworld( game );
          break;
       case GameState_Overworld_MainMenu:

--- a/DragonQuestino/screen.c
+++ b/DragonQuestino/screen.c
@@ -10,11 +10,31 @@ void Screen_Init( Screen_t* screen, uint16_t* buffer )
    screen->textColor = COLOR_WHITE;
 }
 
+void Screen_BackupPalette( Screen_t* screen )
+{
+   uint32_t i;
+
+   for ( i = 0; i < PALETTE_MAX_COLORS; i++ )
+   {
+      screen->backupPalette[i] = screen->palette[i];
+   }
+}
+
+void Screen_RestorePalette( Screen_t* screen )
+{
+   uint32_t i;
+
+   for ( i = 0; i < PALETTE_MAX_COLORS; i++ )
+   {
+      screen->palette[i] = screen->backupPalette[i];
+   }
+}
+
 Bool_t Screen_GetPaletteIndexForColor( Screen_t* screen, uint16_t color, uint32_t* paletteIndex )
 {
    uint32_t i;
 
-   for ( i = 0; i < PALETTE_COLORS; i++ )
+   for ( i = 0; i < screen->paletteColorCount; i++ )
    {
       if ( screen->palette[i] == color )
       {

--- a/DragonQuestino/screen.h
+++ b/DragonQuestino/screen.h
@@ -7,7 +7,7 @@
 #define SCREEN_HEIGHT                  224
 #define SCREEN_PIXELS                  57344
 
-#define PALETTE_COLORS                 256
+#define PALETTE_MAX_COLORS             256
 
 #define COLOR_BLACK                    0x0000
 #define COLOR_WHITE                    0xFFFF
@@ -36,7 +36,9 @@
 typedef struct Screen_t
 {
    uint16_t* buffer;
-   uint16_t palette[PALETTE_COLORS];
+   uint16_t palette[PALETTE_MAX_COLORS];
+   uint16_t backupPalette[PALETTE_MAX_COLORS];
+   uint32_t paletteColorCount;
    uint8_t textBitFields[TEXT_TILE_COUNT][TEXT_TILE_SIZE];
    uint16_t textColor;
 }
@@ -47,6 +49,8 @@ extern "C" {
 #endif
 
 void Screen_Init( Screen_t* screen, uint16_t* buffer );
+void Screen_BackupPalette( Screen_t* screen );
+void Screen_RestorePalette( Screen_t* screen );
 Bool_t Screen_GetPaletteIndexForColor( Screen_t* screen, uint16_t color, uint32_t* paletteIndex );
 void Screen_WipeFromPalette( Screen_t* screen, uint32_t paletteIndex );
 void Screen_WipeColor( Screen_t* screen, uint16_t color );

--- a/DragonQuestino/scrolling_dialog.c
+++ b/DragonQuestino/scrolling_dialog.c
@@ -233,6 +233,7 @@ internal uint32_t ScrollingDialog_GetMessageSectionCount( DialogMessageId_t mess
       case DialogMessageId_Use_SilverHarp: return 2;
       case DialogMessageId_Use_GwaelynsLoveCantUse: return 1;
       case DialogMessageId_Use_GwaelynsLove: return 4;
+      case DialogMessageId_Use_RainbowDropCantUse: return 1;
       case DialogMessageId_Use_RainbowDrop: return 1;
       case DialogMessageId_Use_CursedBelt: return 2;
       case DialogMessageId_Chest_ItemCollected: return 1;
@@ -321,7 +322,8 @@ internal void ScrollingDialog_GetMessageText( ScrollingDialog_t* dialog, char* t
             case 2: sprintf( text, STRING_ITEMUSE_GWAELYNSLOVE_3, dialog->insertionText ); return;
             case 3: sprintf( text, STRING_ITEMUSE_GWAELYNSLOVE_4, player->name ); return;
          }
-      case DialogMessageId_Use_RainbowDrop: strcpy( text, STRING_ITEMUSE_RAINBOWDROP_CANTUSE ); return;
+      case DialogMessageId_Use_RainbowDropCantUse: strcpy( text, STRING_ITEMUSE_RAINBOWDROP_CANTUSE ); return;
+      case DialogMessageId_Use_RainbowDrop: sprintf( text, STRING_ITEMUSE_RAINBOWDROP, player->name ); return;
       case DialogMessageId_Use_CursedBelt:
          switch ( dialog->section )
          {

--- a/DragonQuestino/strings.h
+++ b/DragonQuestino/strings.h
@@ -98,6 +98,7 @@
 #define STRING_ITEMUSE_GWAELYNSLOVE_3_DOUBLE          "%u to the %s and %u to the %s"
 #define STRING_ITEMUSE_GWAELYNSLOVE_4                 "I love thee, %s!\""
 #define STRING_ITEMUSE_RAINBOWDROP_CANTUSE            "The Rainbow Drop cannot be used here."
+#define STRING_ITEMUSE_RAINBOWDROP                    "%s pours the Rainbow Drop into the water."
 #define STRING_ITEMUSE_CURSEDBELT                     "%s puts on the Cursed Belt."
 
 #define STRING_CHEST_ITEMFOUND                        "The chest contains %s!"

--- a/DragonQuestino/tile_map.c
+++ b/DragonQuestino/tile_map.c
@@ -15,6 +15,7 @@ void TileMap_Init( TileMap_t* tileMap, Screen_t* screen )
    Sprite_LoadStatic( &( tileMap->chestSprite ), SPRITE_CHEST_INDEX );
    tileMap->treasureFlags = 0xFFFFFFFF;
    tileMap->isDark = False;
+   tileMap->usedRainbowDrop = False;
 }
 
 void TileMap_ResetViewport( TileMap_t* tileMap )
@@ -93,7 +94,7 @@ void TileMap_IncreaseLightDiameter( TileMap_t* tileMap )
 float TileMap_GetWalkSpeedForTileIndex( TileMap_t* tileMap, uint32_t tileIndex )
 {
    uint16_t tile = tileMap->tiles[( ( tileIndex / tileMap->tilesX ) * TILE_COUNT_X ) + ( tileIndex % tileMap->tilesX )];
-   uint16_t walkSpeed = GET_TILEWALKSPEED( tile );
+   uint16_t walkSpeed = TILE_GET_WALKSPEED( tile );
 
 #if defined( VISUAL_STUDIO_DEV )
 
@@ -148,7 +149,7 @@ void TileMap_Draw( TileMap_t* tileMap )
 
       for ( tileX = firstTileX, screenX = 0; tileX <= lastTileX; tileX++ )
       {
-         textureIndex = GET_TILETEXTUREINDEX( tileMap->tiles[( tileY * TILE_COUNT_X ) + tileX] );
+         textureIndex = TILE_GET_TEXTUREINDEX( tileMap->tiles[( tileY * TILE_COUNT_X ) + tileX] );
          tileWidth = ( tileX == firstTileX ) ? TILE_SIZE - tileOffsetX : ( tileX == lastTileX ) ? ( viewport->x + viewport->w ) % TILE_SIZE : TILE_SIZE;
 
          Screen_DrawMemorySection( tileMap->screen, tileMap->textures[textureIndex].memory, TILE_SIZE,

--- a/DragonQuestino/tile_map.h
+++ b/DragonQuestino/tile_map.h
@@ -27,12 +27,15 @@
 #define TILEMAP_MAX_ACTIVESPRITES      16
 #define TILEMAP_MAX_STATICSPRITES      16
 
-#define GET_TILETEXTUREINDEX( t )      ( ( t ) & 0x1F )
-#define GET_TILEPASSABLE( t )          ( ( ( t ) & 0x20 ) >> 5 )
-#define GET_TILEWALKSPEED( t )         ( ( ( t ) & 0xC0 ) >> 6 )
-#define GET_TILEENCOUNTERABLE( t )     ( ( ( t ) & 0x100 ) >> 8 )
-#define GET_TILEENCOUNTERRATE( t )     ( ( ( t ) & 0x300 ) >> 9 )
-#define GET_TILEDAMAGERATE( t )        ( ( ( t ) & 0x1800 ) >> 11 )
+#define TILE_GET_TEXTUREINDEX( t )      ( ( t ) & 0x1F )
+#define TILE_GET_PASSABLE( t )          ( ( ( t ) & 0x20 ) >> 5 )
+#define TILE_GET_WALKSPEED( t )         ( ( ( t ) & 0xC0 ) >> 6 )
+#define TILE_GET_ENCOUNTERABLE( t )     ( ( ( t ) & 0x100 ) >> 8 )
+#define TILE_GET_ENCOUNTERRATE( t )     ( ( ( t ) & 0x300 ) >> 9 )
+#define TILE_GET_DAMAGERATE( t )        ( ( ( t ) & 0x1800 ) >> 11 )
+
+#define TILE_SET_TEXTUREINDEX( t, i )   ( t ) = ( ( t ) & 0xFFE0 ) | i
+#define TILE_SET_PASSABLE( t, b )       ( t ) = ( ( t ) & 0xFFDF ) | ( b << 5 )
 
 #define TORCH_DIAMETER                 3
 #define RADIANT_DIAMETER               7
@@ -43,6 +46,7 @@
 #define TILEMAP_TANTEGEL_INDEX         7053
 #define TILEMAP_TOKEN_INDEX            16893
 #define TILEMAP_FAIRYFLUTE_INDEX       192
+#define TILEMAP_RAINBOWBRIDGE_INDEX    7914
 
 typedef struct Screen_t Screen_t;
 
@@ -71,13 +75,16 @@ typedef struct TileMap_t
    uint32_t targetLightDiameter;
    uint32_t lightTileCount;
 
-   // bits 1-5: texture index (max 32 textures)
-   // bit 6: is-passable flag
-   // bits 7-8: walk speed (0 = normal, 3 = crawl)
-   // bit 9: is-encounterable flag
-   // bits 10-11: encounter rate
-   // bits 12-13: damage rate
-   // bits 14-16: reserved
+   // MUFFINS: update the editor to check for this when loading the overworld
+   Bool_t usedRainbowDrop;
+
+   // bits 0-4: texture index (max 32 textures)
+   // bit 5: is-passable flag
+   // bits 6-7: walk speed (0 = normal, 3 = crawl)
+   // bit 8: is-encounterable flag
+   // bits 9-10: encounter rate
+   // bits 11-12: damage rate
+   // bits 13-15: reserved
    uint16_t tiles[TILE_COUNT];
    uint32_t tilesX;
    uint32_t tilesY;

--- a/DragonQuestino/tile_map.h
+++ b/DragonQuestino/tile_map.h
@@ -75,7 +75,6 @@ typedef struct TileMap_t
    uint32_t targetLightDiameter;
    uint32_t lightTileCount;
 
-   // MUFFINS: update the editor to check for this when loading the overworld
    Bool_t usedRainbowDrop;
 
    // bits 0-4: texture index (max 32 textures)

--- a/DragonQuestinoEditor/DragonQuestinoEditor/FileOps/DataSourceCodeWriter.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/FileOps/DataSourceCodeWriter.cs
@@ -248,7 +248,14 @@ namespace DragonQuestinoEditor.FileOps
             WriteToFileStream( fs, "         break;\n" );
          }
 
+         WriteToFileStream( fs, "   }\n\n" );
+
+         WriteToFileStream( fs, "   if ( index == TILEMAP_OVERWORLD_ID && tileMap->usedRainbowDrop )\n" );
+         WriteToFileStream( fs, "   {\n" );
+         WriteToFileStream( fs, "      TILE_SET_TEXTUREINDEX( tileMap->tiles[TILEMAP_RAINBOWBRIDGE_INDEX], 13 );\n" );
+         WriteToFileStream( fs, "      TILE_SET_PASSABLE( tileMap->tiles[TILEMAP_RAINBOWBRIDGE_INDEX], True );\n" );
          WriteToFileStream( fs, "   }\n" );
+
          WriteToFileStream( fs, "}\n" );
       }
 

--- a/DragonQuestinoEditor/DragonQuestinoEditor/FileOps/DataSourceCodeWriter.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/FileOps/DataSourceCodeWriter.cs
@@ -59,6 +59,7 @@ namespace DragonQuestinoEditor.FileOps
          WriteToFileStream( fs, "\nvoid Screen_LoadPalette( Screen_t* screen )\n" );
          WriteToFileStream( fs, "{\n" );
          WriteToFileStream( fs, "   uint16_t i;\n\n" );
+         WriteToFileStream( fs, string.Format( "   screen->paletteColorCount = {0};\n\n", _palette.ColorCount ) );
          WriteToFileStream( fs, string.Format( "   for ( i = 0; i < {0}; i++ ) {{ screen->palette[i] = 0; }}\n\n", Constants.PaletteSize ) );
 
          for ( int i = 0; i < _palette.ColorCount; i++ )


### PR DESCRIPTION
## Overview

This will make the Rainbow Bridge appear when using the Rainbow Drop in the correct spot (and facing the correct direction). There's a trippy animation that I just cobbled together, but I think it looks pretty cool. I also updated the Editor to make sure we check whether the Rainbow Drop has been used when loading a tile map, otherwise it'll disappear every time you change maps.