### PR TITLE
Tweaks to Rainbow Bridge animations

### DIFF
--- a/DragonQuestino/enums.h
+++ b/DragonQuestino/enums.h
@@ -37,6 +37,7 @@ typedef enum GameState_t
    GameState_Overworld_ScrollingDialog,
    GameState_Overworld_RainbowBridgeTrippyAnimation,
    GameState_Overworld_RainbowBridgeWhiteoutAnimation,
+   GameState_Overworld_RainbowBridgeFadeInAnimation,
    GameState_Overworld_RainbowBridgePauseAnimation,
    GameState_TileMapTransition,
 

--- a/DragonQuestino/enums.h
+++ b/DragonQuestino/enums.h
@@ -36,7 +36,8 @@ typedef enum GameState_t
    GameState_Overworld_ItemMenu,
    GameState_Overworld_ScrollingDialog,
    GameState_Overworld_RainbowBridgeTrippyAnimation,
-   GameState_Overworld_RainbowBridgeFinalAnimation,
+   GameState_Overworld_RainbowBridgeWhiteoutAnimation,
+   GameState_Overworld_RainbowBridgePauseAnimation,
    GameState_TileMapTransition,
 
    GameState_Count

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -5,7 +5,8 @@ internal void Game_TicOverworld( Game_t* game );
 internal void Game_TicOverworldWashing( Game_t* game );
 internal void Game_TicTileMapTransition( Game_t* game );
 internal void Game_TicRainbowBridgeTrippyAnimation( Game_t* game );
-internal void Game_TicRainbowBridgeFinalAnimation( Game_t* game );
+internal void Game_TicRainbowBridgeWhiteoutAnimation( Game_t* game );
+internal void Game_TicRainbowBridgePauseAnimation( Game_t* game );
 internal void Game_CollectTreasure( Game_t* game, uint32_t treasureFlag );
 
 void Game_Init( Game_t* game, uint16_t* screenBuffer )
@@ -50,8 +51,11 @@ void Game_Tic( Game_t* game )
       case GameState_Overworld_RainbowBridgeTrippyAnimation:
          Game_TicRainbowBridgeTrippyAnimation( game );
          break;
-      case GameState_Overworld_RainbowBridgeFinalAnimation:
-         Game_TicRainbowBridgeFinalAnimation( game );
+      case GameState_Overworld_RainbowBridgeWhiteoutAnimation:
+         Game_TicRainbowBridgeWhiteoutAnimation( game );
+         break;
+      case GameState_Overworld_RainbowBridgePauseAnimation:
+         Game_TicRainbowBridgePauseAnimation( game );
          break;
       case GameState_TileMapTransition:
          Game_TicTileMapTransition( game );
@@ -77,8 +81,11 @@ void Game_ChangeState( Game_t* game, GameState_t newState )
       case GameState_Overworld_RainbowBridgeTrippyAnimation:
          game->rainbowBridgeTrippySecondsElapsed = 0.0f;
          break;
-      case GameState_Overworld_RainbowBridgeFinalAnimation:
-         game->rainbowBridgeFinalSecondsElapsed = 0.0f;
+      case GameState_Overworld_RainbowBridgeWhiteoutAnimation:
+         game->rainbowBridgeWhiteoutSecondsElapsed = 0.0f;
+         break;
+      case GameState_Overworld_RainbowBridgePauseAnimation:
+         game->rainbowBridgePauseSecondsElapsed = 0.0f;
          break;
    }
 }
@@ -253,7 +260,7 @@ internal void Game_TicRainbowBridgeTrippyAnimation( Game_t* game )
       game->tileMap.usedRainbowDrop = True;
       TILE_SET_TEXTUREINDEX( game->tileMap.tiles[TILEMAP_RAINBOWBRIDGE_INDEX], 13 );
       TILE_SET_PASSABLE( game->tileMap.tiles[TILEMAP_RAINBOWBRIDGE_INDEX], True );
-      Game_ChangeState( game, GameState_Overworld_RainbowBridgeFinalAnimation );
+      Game_ChangeState( game, GameState_Overworld_RainbowBridgeWhiteoutAnimation );
    }
    else
    {
@@ -269,12 +276,22 @@ internal void Game_TicRainbowBridgeTrippyAnimation( Game_t* game )
    }
 }
 
-internal void Game_TicRainbowBridgeFinalAnimation( Game_t* game )
+internal void Game_TicRainbowBridgeWhiteoutAnimation( Game_t* game )
 {
    Screen_WipeColor( &( game->screen ), COLOR_WHITE );
-   game->rainbowBridgeFinalSecondsElapsed += CLOCK_FRAME_SECONDS;
+   game->rainbowBridgeWhiteoutSecondsElapsed += CLOCK_FRAME_SECONDS;
 
-   if ( game->rainbowBridgeFinalSecondsElapsed > RAINBOW_BRIDGE_FINAL_TOTAL_SECONDS )
+   if ( game->rainbowBridgeWhiteoutSecondsElapsed > RAINBOW_BRIDGE_WHITEOUT_TOTAL_SECONDS )
+   {
+      Game_ChangeState( game, GameState_Overworld_RainbowBridgePauseAnimation );
+   }
+}
+
+internal void Game_TicRainbowBridgePauseAnimation( Game_t* game )
+{
+   game->rainbowBridgePauseSecondsElapsed += CLOCK_FRAME_SECONDS;
+
+   if ( game->rainbowBridgePauseSecondsElapsed > RAINBOW_BRIDGE_PAUSE_TOTAL_SECONDS )
    {
       Game_ChangeState( game, GameState_Overworld );
    }

--- a/DragonQuestino/game.h
+++ b/DragonQuestino/game.h
@@ -10,13 +10,14 @@
 #include "menu.h"
 #include "scrolling_dialog.h"
 
-#define TILEMAP_SWAP_SECONDS                 0.4f
-#define OVERWORLD_INACTIVE_STATUS_SECONDS    1.0f
-#define OVERWORLD_LIGHTING_FRAME_SECONDS     0.1f
-#define OVERWORLD_WASH_TOTAL_SECONDS         0.2f
-#define RAINBOW_BRIDGE_TRIPPY_TOTAL_SECONDS  5.0f
-#define RAINBOW_BRIDGE_FINAL_TOTAL_SECONDS   1.3f
-#define COLLISION_THETA                      0.001f
+#define TILEMAP_SWAP_SECONDS                    0.4f
+#define OVERWORLD_INACTIVE_STATUS_SECONDS       1.0f
+#define OVERWORLD_LIGHTING_FRAME_SECONDS        0.1f
+#define OVERWORLD_WASH_TOTAL_SECONDS            0.2f
+#define RAINBOW_BRIDGE_TRIPPY_TOTAL_SECONDS     10.0f
+#define RAINBOW_BRIDGE_WHITEOUT_TOTAL_SECONDS   3.0f
+#define RAINBOW_BRIDGE_PAUSE_TOTAL_SECONDS      2.0f
+#define COLLISION_THETA                         0.001f
 
 typedef struct Game_t
 {
@@ -37,7 +38,8 @@ typedef struct Game_t
 
    float lightingSecondsElapsed;
    float rainbowBridgeTrippySecondsElapsed;
-   float rainbowBridgeFinalSecondsElapsed;
+   float rainbowBridgeWhiteoutSecondsElapsed;
+   float rainbowBridgePauseSecondsElapsed;
 }
 Game_t;
 

--- a/DragonQuestino/game.h
+++ b/DragonQuestino/game.h
@@ -15,7 +15,8 @@
 #define OVERWORLD_LIGHTING_FRAME_SECONDS        0.1f
 #define OVERWORLD_WASH_TOTAL_SECONDS            0.2f
 #define RAINBOW_BRIDGE_TRIPPY_TOTAL_SECONDS     10.0f
-#define RAINBOW_BRIDGE_WHITEOUT_TOTAL_SECONDS   3.0f
+#define RAINBOW_BRIDGE_WHITEOUT_TOTAL_SECONDS   2.0f
+#define RAINBOW_BRIDGE_FADEIN_TOTAL_SECONDS     2.0f
 #define RAINBOW_BRIDGE_PAUSE_TOTAL_SECONDS      2.0f
 #define COLLISION_THETA                         0.001f
 
@@ -39,6 +40,7 @@ typedef struct Game_t
    float lightingSecondsElapsed;
    float rainbowBridgeTrippySecondsElapsed;
    float rainbowBridgeWhiteoutSecondsElapsed;
+   float rainbowBridgeFadeInSecondsElapsed;
    float rainbowBridgePauseSecondsElapsed;
 }
 Game_t;

--- a/DragonQuestino/game_render.c
+++ b/DragonQuestino/game_render.c
@@ -11,6 +11,7 @@ void Game_Draw( Game_t* game )
       case GameState_Overworld:
       case GameState_Overworld_Washing:
       case GameState_Overworld_RainbowBridgeTrippyAnimation:
+      case GameState_Overworld_RainbowBridgeFadeInAnimation:
       case GameState_Overworld_RainbowBridgePauseAnimation:
          Game_DrawOverworld( game );
          break;

--- a/DragonQuestino/game_render.c
+++ b/DragonQuestino/game_render.c
@@ -11,6 +11,7 @@ void Game_Draw( Game_t* game )
       case GameState_Overworld:
       case GameState_Overworld_Washing:
       case GameState_Overworld_RainbowBridgeTrippyAnimation:
+      case GameState_Overworld_RainbowBridgePauseAnimation:
          Game_DrawOverworld( game );
          break;
       case GameState_Overworld_MainMenu:


### PR DESCRIPTION
## Overview

This lengthens the trippy animation time, and also fades back in and pauses for a couple seconds after the whiteout is over.