### PR TITLE
Only allow Evac spell in dungeons

### DIFF
--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -15,7 +15,7 @@ void Game_Init( Game_t* game, uint16_t* screenBuffer )
    Sprite_LoadPlayer( &( game->player.sprite ) );
    Clock_Init( &( game->clock ) );
    Input_Init( &( game->input ) );
-   Player_Init( &( game->player ), &( game->screen ) );
+   Player_Init( &( game->player ), &( game->screen ), &( game->tileMap ) );
    Menu_Init( &( game->menu ), &( game->screen ), &( game->player ) );
    ScrollingDialog_Init( &( game->scrollingDialog ), &( game->screen ), &( game->player ) );
 

--- a/DragonQuestino/game_data.c
+++ b/DragonQuestino/game_data.c
@@ -2668,6 +2668,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
    {
       case 0:
          tileMap->id = 0;
+         tileMap->isDungeon = False;
          tileMap->isDark = False;
          tileMap->tilesX = 140;
          tileMap->tilesY = 135;
@@ -6108,6 +6109,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 1:
          tileMap->id = 1;
+         tileMap->isDungeon = False;
          tileMap->isDark = False;
          tileMap->tilesX = 20;
          tileMap->tilesY = 15;
@@ -6160,6 +6162,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 2:
          tileMap->id = 2;
+         tileMap->isDungeon = False;
          tileMap->isDark = False;
          tileMap->tilesX = 20;
          tileMap->tilesY = 15;
@@ -6220,6 +6223,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 3:
          tileMap->id = 3;
+         tileMap->isDungeon = False;
          tileMap->isDark = False;
          tileMap->tilesX = 32;
          tileMap->tilesY = 32;
@@ -6738,6 +6742,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 4:
          tileMap->id = 4;
+         tileMap->isDungeon = False;
          tileMap->isDark = False;
          tileMap->tilesX = 32;
          tileMap->tilesY = 32;
@@ -7104,6 +7109,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 5:
          tileMap->id = 5;
+         tileMap->isDungeon = False;
          tileMap->isDark = False;
          tileMap->tilesX = 20;
          tileMap->tilesY = 15;
@@ -7133,6 +7139,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 6:
          tileMap->id = 6;
+         tileMap->isDungeon = False;
          tileMap->isDark = False;
          tileMap->tilesX = 20;
          tileMap->tilesY = 15;
@@ -7166,6 +7173,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 7:
          tileMap->id = 7;
+         tileMap->isDungeon = False;
          tileMap->isDark = False;
          tileMap->tilesX = 22;
          tileMap->tilesY = 22;
@@ -7412,6 +7420,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 8:
          tileMap->id = 8;
+         tileMap->isDungeon = False;
          tileMap->isDark = False;
          tileMap->tilesX = 20;
          tileMap->tilesY = 15;
@@ -7471,6 +7480,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 9:
          tileMap->id = 9;
+         tileMap->isDungeon = False;
          tileMap->isDark = False;
          tileMap->tilesX = 22;
          tileMap->tilesY = 22;
@@ -7812,6 +7822,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 10:
          tileMap->id = 10;
+         tileMap->isDungeon = False;
          tileMap->isDark = False;
          tileMap->tilesX = 30;
          tileMap->tilesY = 31;
@@ -8341,6 +8352,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 11:
          tileMap->id = 11;
+         tileMap->isDungeon = False;
          tileMap->isDark = False;
          tileMap->tilesX = 20;
          tileMap->tilesY = 15;
@@ -8539,6 +8551,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 12:
          tileMap->id = 12;
+         tileMap->isDungeon = False;
          tileMap->isDark = False;
          tileMap->tilesX = 26;
          tileMap->tilesY = 26;
@@ -8930,6 +8943,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 13:
          tileMap->id = 13;
+         tileMap->isDungeon = False;
          tileMap->isDark = False;
          tileMap->tilesX = 32;
          tileMap->tilesY = 32;
@@ -9608,6 +9622,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 14:
          tileMap->id = 14;
+         tileMap->isDungeon = False;
          tileMap->isDark = False;
          tileMap->tilesX = 20;
          tileMap->tilesY = 15;
@@ -9644,6 +9659,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 15:
          tileMap->id = 15;
+         tileMap->isDungeon = False;
          tileMap->isDark = False;
          tileMap->tilesX = 20;
          tileMap->tilesY = 15;
@@ -9699,6 +9715,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 16:
          tileMap->id = 16;
+         tileMap->isDungeon = True;
          tileMap->isDark = True;
          tileMap->tilesX = 32;
          tileMap->tilesY = 28;
@@ -9757,6 +9774,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 17:
          tileMap->id = 17;
+         tileMap->isDungeon = True;
          tileMap->isDark = True;
          tileMap->tilesX = 32;
          tileMap->tilesY = 28;
@@ -9813,6 +9831,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 18:
          tileMap->id = 18;
+         tileMap->isDungeon = True;
          tileMap->isDark = True;
          tileMap->tilesX = 36;
          tileMap->tilesY = 32;
@@ -9911,6 +9930,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 19:
          tileMap->id = 19;
+         tileMap->isDungeon = True;
          tileMap->isDark = True;
          tileMap->tilesX = 36;
          tileMap->tilesY = 32;
@@ -10010,6 +10030,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 20:
          tileMap->id = 20;
+         tileMap->isDungeon = True;
          tileMap->isDark = True;
          tileMap->tilesX = 28;
          tileMap->tilesY = 49;
@@ -10110,6 +10131,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 21:
          tileMap->id = 21;
+         tileMap->isDungeon = True;
          tileMap->isDark = True;
          tileMap->tilesX = 42;
          tileMap->tilesY = 38;
@@ -10248,6 +10270,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 22:
          tileMap->id = 22;
+         tileMap->isDungeon = True;
          tileMap->isDark = True;
          tileMap->tilesX = 36;
          tileMap->tilesY = 30;
@@ -10345,6 +10368,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 23:
          tileMap->id = 23;
+         tileMap->isDungeon = True;
          tileMap->isDark = True;
          tileMap->tilesX = 42;
          tileMap->tilesY = 38;
@@ -10517,6 +10541,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 24:
          tileMap->id = 24;
+         tileMap->isDungeon = True;
          tileMap->isDark = True;
          tileMap->tilesX = 32;
          tileMap->tilesY = 27;
@@ -10563,6 +10588,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 25:
          tileMap->id = 25;
+         tileMap->isDungeon = True;
          tileMap->isDark = False;
          tileMap->tilesX = 22;
          tileMap->tilesY = 22;
@@ -10767,6 +10793,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 26:
          tileMap->id = 26;
+         tileMap->isDungeon = True;
          tileMap->isDark = True;
          tileMap->tilesX = 42;
          tileMap->tilesY = 38;
@@ -10976,6 +11003,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 27:
          tileMap->id = 27;
+         tileMap->isDungeon = True;
          tileMap->isDark = True;
          tileMap->tilesX = 32;
          tileMap->tilesY = 28;
@@ -11048,6 +11076,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 28:
          tileMap->id = 28;
+         tileMap->isDungeon = True;
          tileMap->isDark = True;
          tileMap->tilesX = 32;
          tileMap->tilesY = 28;
@@ -11137,6 +11166,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 29:
          tileMap->id = 29;
+         tileMap->isDungeon = True;
          tileMap->isDark = True;
          tileMap->tilesX = 32;
          tileMap->tilesY = 28;
@@ -11264,6 +11294,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 30:
          tileMap->id = 30;
+         tileMap->isDungeon = True;
          tileMap->isDark = True;
          tileMap->tilesX = 32;
          tileMap->tilesY = 28;
@@ -11326,6 +11357,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 31:
          tileMap->id = 31;
+         tileMap->isDungeon = True;
          tileMap->isDark = True;
          tileMap->tilesX = 32;
          tileMap->tilesY = 23;
@@ -11353,6 +11385,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 32:
          tileMap->id = 32;
+         tileMap->isDungeon = True;
          tileMap->isDark = True;
          tileMap->tilesX = 32;
          tileMap->tilesY = 23;
@@ -11384,6 +11417,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 33:
          tileMap->id = 33;
+         tileMap->isDungeon = True;
          tileMap->isDark = False;
          tileMap->tilesX = 32;
          tileMap->tilesY = 32;
@@ -11684,6 +11718,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 34:
          tileMap->id = 34;
+         tileMap->isDungeon = False;
          tileMap->isDark = False;
          tileMap->tilesX = 20;
          tileMap->tilesY = 15;
@@ -11736,6 +11771,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 35:
          tileMap->id = 35;
+         tileMap->isDungeon = False;
          tileMap->isDark = False;
          tileMap->tilesX = 20;
          tileMap->tilesY = 15;
@@ -11788,6 +11824,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 36:
          tileMap->id = 36;
+         tileMap->isDungeon = False;
          tileMap->isDark = False;
          tileMap->tilesX = 20;
          tileMap->tilesY = 15;
@@ -11808,6 +11845,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          break;
       case 37:
          tileMap->id = 37;
+         tileMap->isDungeon = False;
          tileMap->isDark = False;
          tileMap->tilesX = 20;
          tileMap->tilesY = 15;

--- a/DragonQuestino/game_input.c
+++ b/DragonQuestino/game_input.c
@@ -233,7 +233,7 @@ internal void Game_OpenOverworldSpellMenu( Game_t* game )
    {
       Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Spell_None );
    }
-   else if ( SPELL_GET_MAPUSEABLECOUNT( game->player.spells ) )
+   else if ( SPELL_GET_MAPUSEABLECOUNT( game->player.spells, game->tileMap.isDungeon ) )
    {
       Game_OpenMenu( game, MenuId_OverworldSpell );
    }

--- a/DragonQuestino/menu.c
+++ b/DragonQuestino/menu.c
@@ -2,6 +2,7 @@
 #include "screen.h"
 #include "player.h"
 #include "clock.h"
+#include "tile_map.h"
 
 internal void Menu_DrawCarat( Menu_t* menu );
 internal void Menu_LoadOverworld( Menu_t* menu );
@@ -195,7 +196,7 @@ internal void Menu_LoadOverworldSpell( Menu_t* menu )
 
    strcpy( menu->title, STRING_OVERWORLD_MENU_SPELL );
 
-   menu->itemCount = SPELL_GET_MAPUSEABLECOUNT( spells );
+   menu->itemCount = SPELL_GET_MAPUSEABLECOUNT( spells, menu->player->tileMap->isDungeon );
    menu->itemsPerColumn = menu->itemCount;
    menu->selectedIndex = 0;
    menu->position.x = 152;
@@ -227,7 +228,7 @@ internal void Menu_LoadOverworldSpell( Menu_t* menu )
       menu->items[i].command = MenuCommand_Spell_Glow;
       i++;
    }
-   if ( SPELL_HAS_EVAC( spells ) )
+   if ( menu->player->tileMap->isDungeon && SPELL_HAS_EVAC( spells ) )
    {
       sprintf( menu->items[i].text, STRING_SPELLMENU_EVAC );
       menu->items[i].command = MenuCommand_Spell_Evac;

--- a/DragonQuestino/player.c
+++ b/DragonQuestino/player.c
@@ -4,9 +4,10 @@
 #include "math.h"
 #include "tables.h"
 
-void Player_Init( Player_t* player, Screen_t* screen )
+void Player_Init( Player_t* player, Screen_t* screen, TileMap_t* tileMap )
 {
    player->screen = screen;
+   player->tileMap = tileMap;
 
    player->tileIndex = 148; // sort of in front of King Lorik
    player->sprite.position.x = (float)( TILE_SIZE * 8 );

--- a/DragonQuestino/player.h
+++ b/DragonQuestino/player.h
@@ -6,6 +6,7 @@
 #include "battle_stats.h"
 
 typedef struct Screen_t Screen_t;
+typedef struct TileMap_t TileMap_t;
 
 #define SPELL_HAS_HEAL( x )                     ( ( x ) & 0x1 )
 #define SPELL_HAS_SIZZ( x )                     ( ( x ) & 0x2 )
@@ -29,10 +30,10 @@ typedef struct Screen_t Screen_t;
 #define SPELL_SET_HASMIDHEAL( x )               ( x ) |= 0x100
 #define SPELL_SET_HASSIZZLE( x )                ( x ) |= 0x200
 
-#define SPELL_GET_MAPUSEABLECOUNT( x )          ( 0 + \
+#define SPELL_GET_MAPUSEABLECOUNT( x, d )       ( 0 + \
                                                 ( SPELL_HAS_HEAL( x ) ? 1 : 0 ) + \
                                                 ( SPELL_HAS_GLOW( x ) ? 1 : 0 ) + \
-                                                ( SPELL_HAS_EVAC( x ) ? 1 : 0 ) + \
+                                                ( ( ( d ) && SPELL_HAS_EVAC( x ) ) ? 1 : 0 ) + \
                                                 ( SPELL_HAS_ZOOM( x ) ? 1 : 0 ) + \
                                                 ( SPELL_HAS_REPEL( x ) ? 1 : 0 ) + \
                                                 ( SPELL_HAS_MIDHEAL( x ) ? 1 : 0 ) )
@@ -97,6 +98,7 @@ typedef struct Screen_t Screen_t;
 typedef struct Player_t
 {
    Screen_t* screen;
+   TileMap_t* tileMap;
 
    ActiveSprite_t sprite;
    Vector2i32_t spriteOffset;
@@ -149,7 +151,7 @@ Player_t;
 extern "C" {
 #endif
 
-void Player_Init( Player_t* player, Screen_t* screen );
+void Player_Init( Player_t* player, Screen_t* screen, TileMap_t* tileMap );
 uint16_t Player_GetLevel( Player_t* player );
 uint16_t Player_GetExperienceRemaining( Player_t* player );
 uint16_t Player_CollectGold( Player_t* player, uint16_t gold );

--- a/DragonQuestino/tile_map.c
+++ b/DragonQuestino/tile_map.c
@@ -19,6 +19,7 @@ void TileMap_Init( TileMap_t* tileMap, Screen_t* screen )
    Sprite_LoadStatic( &( tileMap->doorSprite ), SPRITE_DOOR_INDEX );
    tileMap->doorFlags = 0xFFFFFFFF;
 
+   tileMap->isDungeon = False;
    tileMap->isDark = False;
    tileMap->usedRainbowDrop = False;
    tileMap->foundHiddenStairs = False;

--- a/DragonQuestino/tile_map.h
+++ b/DragonQuestino/tile_map.h
@@ -81,6 +81,7 @@ typedef struct TileMap_t
    Screen_t* screen;
    uint32_t id;
 
+   Bool_t isDungeon;
    Bool_t isDark;
    uint32_t glowDiameter;
    uint32_t targetGlowDiameter;

--- a/DragonQuestinoEditor/DragonQuestinoEditor/FileOps/DataSourceCodeWriter.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/FileOps/DataSourceCodeWriter.cs
@@ -129,6 +129,7 @@ namespace DragonQuestinoEditor.FileOps
 
             WriteToFileStream( fs, string.Format( "      case {0}:\n", tileMap.Id ) );
             WriteToFileStream( fs, string.Format( "         tileMap->id = {0};\n", tm ) );
+            WriteToFileStream( fs, string.Format( "         tileMap->isDungeon = {0};\n", tileMap.IsDungeon ? "True" : "False" ) );
             WriteToFileStream( fs, string.Format( "         tileMap->isDark = {0};\n", tileMap.IsDark ? "True" : "False" ) );
             WriteToFileStream( fs, string.Format( "         tileMap->tilesX = {0};\n", tileMap.TilesX ) );
             WriteToFileStream( fs, string.Format( "         tileMap->tilesY = {0};\n", tileMap.TilesY ) );

--- a/DragonQuestinoEditor/DragonQuestinoEditor/FileOps/TileMapSaveData.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/FileOps/TileMapSaveData.cs
@@ -6,6 +6,7 @@ namespace DragonQuestinoEditor.FileOps
    {
       public int Id { get; set; }
       public string? Name { get; set; }
+      public bool IsDungeon { get; set; }
       public bool IsDark { get; set; }
       public List<TileSaveData> Tiles { get; set; } = [];
       public int TilesX { get; set; }
@@ -19,6 +20,7 @@ namespace DragonQuestinoEditor.FileOps
       {
          Id = tileMap.Id;
          Name = tileMap.Name;
+         IsDungeon = tileMap.IsDungeon;
          IsDark = tileMap.IsDark;
          TilesX = tileMap.TilesX;
          TilesY = tileMap.TilesY;

--- a/DragonQuestinoEditor/DragonQuestinoEditor/ViewModels/MainWindowViewModel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/ViewModels/MainWindowViewModel.cs
@@ -224,7 +224,7 @@ namespace DragonQuestinoEditor.ViewModels
          if ( result.HasValue && result.Value )
          {
             int id = TileMaps[^1].Id + 1;
-            var newTileMap = new TileMapViewModel( _tileSet, id, window.NewTileMapName, false, window.NewTilesX, window.NewTilesY, Constants.TileTextureDefaultIndex );
+            var newTileMap = new TileMapViewModel( _tileSet, id, window.NewTileMapName, false, false, window.NewTilesX, window.NewTilesY, Constants.TileTextureDefaultIndex );
 
             foreach ( var tile in newTileMap.Tiles )
             {

--- a/DragonQuestinoEditor/DragonQuestinoEditor/ViewModels/TileMapViewModel.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/ViewModels/TileMapViewModel.cs
@@ -39,6 +39,13 @@ namespace DragonQuestinoEditor.ViewModels
          set => SetProperty( ref _name, value );
       }
 
+      private bool _isDungeon;
+      public bool IsDungeon
+      {
+         get => _isDungeon;
+         set => SetProperty( ref _isDungeon, value );
+      }
+
       private bool _isDark;
       public bool IsDark
       {
@@ -46,10 +53,11 @@ namespace DragonQuestinoEditor.ViewModels
          set => SetProperty( ref _isDark, value );
       }
 
-      public TileMapViewModel( TileSet tileSet, int id, string? name, bool isDark, int tilesX, int tilesY, int defaultTileTextureIndex )
+      public TileMapViewModel( TileSet tileSet, int id, string? name, bool isDungeon, bool isDark, int tilesX, int tilesY, int defaultTileTextureIndex )
       {
          _id = id;
          _name = name;
+         _isDungeon = isDungeon;
          _isDark = isDark;
          _tilesX = tilesX;
          _tilesY = tilesY;
@@ -64,6 +72,7 @@ namespace DragonQuestinoEditor.ViewModels
       {
          _id = saveData.Id;
          _name = saveData.Name;
+         _isDungeon = saveData.IsDungeon;
          _isDark = saveData.IsDark;
          _tilesX = saveData.TilesX;
          _tilesY = saveData.TilesY;


### PR DESCRIPTION
## Overview

I had to add an `isDungeon` flag to tile maps, but this allows us to tell whether Evac is possible from any given tile map.