### PR TITLE
Small Glow refactor

### DIFF
--- a/DragonQuestino/game_input.c
+++ b/DragonQuestino/game_input.c
@@ -186,16 +186,7 @@ internal void Game_HandleMenuInput( Game_t* game )
          case MenuCommand_Item_Herb: Game_UseHerb( game ); break;
          case MenuCommand_Item_Wing: Game_UseWing( game ); break;
          case MenuCommand_Item_FairyWater: Game_UseFairyWater( game ); break;
-         case MenuCommand_Item_Torch:
-            if ( game->tileMap.isDark )
-            {
-               Game_UseTorch( game ); break;
-            }
-            else
-            {
-               Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Use_TorchCantUse );
-            }
-            break;
+         case MenuCommand_Item_Torch: Game_UseTorch( game ); break;
          case MenuCommand_Item_SilverHarp: Game_UseSilverHarp( game ); break;
          case MenuCommand_Item_FairyFlute: Game_UseFairyFlute( game ); break;
          case MenuCommand_Item_GwaelynsLove: Game_UseGwaelynsLove( game ); break;

--- a/DragonQuestino/game_items.c
+++ b/DragonQuestino/game_items.c
@@ -22,15 +22,22 @@ void Game_UseFairyWater( Game_t* game )
 
 void Game_UseTorch( Game_t* game )
 {
-   if ( game->tileMap.isDark && game->tileMap.glowDiameter <= TORCH_DIAMETER )
+   if ( game->tileMap.isDark )
    {
-      TileMap_SetTargetGlowDiameter( &( game->tileMap ), TORCH_DIAMETER );
-      game->tileMap.glowTileCount = 0;
-      game->glowExpandSeconds = GLOW_EXPAND_FRAME_SECONDS; // push one frame immediately
-   }
+      if ( game->tileMap.glowDiameter <= TORCH_DIAMETER )
+      {
+         TileMap_SetTargetGlowDiameter( &( game->tileMap ), TORCH_DIAMETER );
+         game->tileMap.glowTileCount = 0;
+         game->glowExpandSeconds = GLOW_EXPAND_FRAME_SECONDS; // push one frame immediately
+      }
 
-   ITEM_SET_TORCHCOUNT( game->player.items, ITEM_GET_TORCHCOUNT( game->player.items ) - 1 );
-   Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Use_Torch );
+      ITEM_SET_TORCHCOUNT( game->player.items, ITEM_GET_TORCHCOUNT( game->player.items ) - 1 );
+      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Use_Torch );
+   }
+   else
+   {
+      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Use_TorchCantUse );
+   }
 }
 
 void Game_UseSilverHarp( Game_t* game )

--- a/DragonQuestino/game_spells.c
+++ b/DragonQuestino/game_spells.c
@@ -27,7 +27,7 @@ void Game_CastGlow( Game_t* game )
    {
       Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Spell_NotEnoughMp );
    }
-   else
+   else if ( game->tileMap.isDark )
    {
       if ( game->tileMap.glowDiameter <= GLOW_SPELL_DIAMETER )
       {


### PR DESCRIPTION
## Overview

Turns out this isn't actually bug like I thought it was. I thought you could cast Glow when the tile map isn't dark, but I forgot it doesn't even show  up on the spell list in that case. I did do a little refactor around using the torch though, so at least there's that.