### PR TITLE
Removed scrolling dialog type enum

### DIFF
--- a/DragonQuestino/enums.h
+++ b/DragonQuestino/enums.h
@@ -133,14 +133,6 @@ typedef enum MenuCommand_t
 }
 MenuCommand_t;
 
-typedef enum ScrollingDialogType_t
-{
-   ScrollingDialogType_Overworld = 0,
-
-   ScrollingDialogType_Count
-}
-ScrollingDialogType_t;
-
 typedef enum DialogMessageId_t
 {
    DialogMessageId_Talk_NobodyThere = 0,

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -154,16 +154,10 @@ void Game_OpenMenu( Game_t* game, MenuId_t id )
    }
 }
 
-void Game_OpenScrollingDialog( Game_t* game, ScrollingDialogType_t type, DialogMessageId_t messageId )
+void Game_OpenScrollingDialog( Game_t* game, DialogMessageId_t messageId )
 {
-   ScrollingDialog_Load( &( game->scrollingDialog ), type, messageId );
-
-   switch ( type )
-   {
-      case ScrollingDialogType_Overworld:
-         Game_ChangeState( game, GameState_Overworld_ScrollingDialog );
-         break;
-   }
+   ScrollingDialog_Load( &( game->scrollingDialog ), messageId );
+   Game_ChangeState( game, GameState_Overworld_ScrollingDialog );
 }
 
 void Game_Search( Game_t* game )
@@ -174,19 +168,19 @@ void Game_Search( Game_t* game )
    {
       Player_CollectItem( &( game->player ), Item_Token );
       ScrollingDialog_SetInsertionText( &( game->scrollingDialog ), STRING_FOUNDITEM_TOKEN );
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Search_FoundItem );
+      Game_OpenScrollingDialog( game, DialogMessageId_Search_FoundItem );
    }
    else if ( game->tileMap.id == TILEMAP_KOL_ID && game->player.tileIndex == TILEMAP_FAIRYFLUTE_INDEX && !ITEM_HAS_FAIRYFLUTE( game->player.items ) )
    {
       Player_CollectItem( &( game->player ), Item_FairyFlute );
       ScrollingDialog_SetInsertionText( &( game->scrollingDialog ), STRING_FOUNDITEM_FAIRYFLUTE );
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Search_FoundItem );
+      Game_OpenScrollingDialog( game, DialogMessageId_Search_FoundItem );
    }
    else if ( game->tileMap.id == TILEMAP_CHARLOCK_ID && game->player.tileIndex == TILEMAP_HIDDENSTAIRS_INDEX && !game->gameFlags.foundHiddenStairs )
    {
       game->gameFlags.foundHiddenStairs = True;
       TileMap_LoadHiddenStairs( &( game->tileMap ) );
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Search_FoundHiddenStairs );
+      Game_OpenScrollingDialog( game, DialogMessageId_Search_FoundHiddenStairs );
    }
    else
    {
@@ -198,7 +192,7 @@ void Game_Search( Game_t* game )
       }
       else
       {
-         Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Search_NothingFound );
+         Game_OpenScrollingDialog( game, DialogMessageId_Search_NothingFound );
       }
    }
 }
@@ -212,7 +206,7 @@ void Game_OpenDoor( Game_t* game )
    {
       if ( !ITEM_GET_KEYCOUNT( game->player.items ) )
       {
-         Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Door_NoKeys );
+         Game_OpenScrollingDialog( game, DialogMessageId_Door_NoKeys );
       }
       else
       {
@@ -223,7 +217,7 @@ void Game_OpenDoor( Game_t* game )
    }
    else
    {
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Door_None );
+      Game_OpenScrollingDialog( game, DialogMessageId_Door_None );
    }
 }
 
@@ -235,7 +229,7 @@ void Game_ApplyHealing( Game_t* game, uint8_t minHp, uint8_t maxHp, DialogMessag
    amount = Player_RestoreHitPoints( &( game->player ), Random_u8( minHp, maxHp ) );
    sprintf( str, "%u", amount );
    ScrollingDialog_SetInsertionText( &( game->scrollingDialog ), str );
-   Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, ( amount == 1 ) ? msg1: msg2 );
+   Game_OpenScrollingDialog( game, ( amount == 1 ) ? msg1: msg2 );
 }
 
 internal void Game_TicOverworld( Game_t* game )
@@ -276,7 +270,7 @@ internal void Game_CollectTreasure( Game_t* game, uint32_t treasureFlag )
          ScrollingDialog_SetInsertionText( &( game->scrollingDialog ), STRING_CHESTCOLLECT_STONEOFSUNLIGHT );
          break;
       case 0x100:       // Erdrick's Cave, the tablet. this is not an item that can be collected.
-         Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Chest_Tablet );
+         Game_OpenScrollingDialog( game, DialogMessageId_Chest_Tablet );
          game->gameFlags.treasures ^= treasureFlag;
          return;
       case 0x200:       // Rimuldar Inn
@@ -299,7 +293,7 @@ internal void Game_CollectTreasure( Game_t* game, uint32_t treasureFlag )
          if ( Random_Percent() <= 5 )
          {
             game->gameFlags.treasures ^= treasureFlag;
-            Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Chest_DeathNecklace );
+            Game_OpenScrollingDialog( game, DialogMessageId_Chest_DeathNecklace );
             return;
          }
          else
@@ -373,10 +367,10 @@ internal void Game_CollectTreasure( Game_t* game, uint32_t treasureFlag )
    if ( collected )
    {
       game->gameFlags.treasures ^= treasureFlag;
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, ( gold > 0 ) ? DialogMessageId_Chest_GoldCollected : DialogMessageId_Chest_ItemCollected );
+      Game_OpenScrollingDialog( game, ( gold > 0 ) ? DialogMessageId_Chest_GoldCollected : DialogMessageId_Chest_ItemCollected );
    }
    else
    {
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, ( gold > 0 ) ? DialogMessageId_Chest_GoldNoSpace : DialogMessageId_Chest_ItemNoSpace );
+      Game_OpenScrollingDialog( game, ( gold > 0 ) ? DialogMessageId_Chest_GoldNoSpace : DialogMessageId_Chest_ItemNoSpace );
    }
 }

--- a/DragonQuestino/game.h
+++ b/DragonQuestino/game.h
@@ -59,7 +59,7 @@ void Game_Tic( Game_t* game );
 void Game_ChangeState( Game_t* game, GameState_t newState );
 void Game_EnterTargetPortal( Game_t* game );
 void Game_OpenMenu( Game_t* game, MenuId_t id );
-void Game_OpenScrollingDialog( Game_t* game, ScrollingDialogType_t type, DialogMessageId_t messageId );
+void Game_OpenScrollingDialog( Game_t* game, DialogMessageId_t messageId );
 void Game_Search( Game_t* game );
 void Game_OpenDoor( Game_t* game );
 void Game_ApplyHealing( Game_t* game, uint8_t minHp, uint8_t maxHp, DialogMessageId_t msg1, DialogMessageId_t msg2 );

--- a/DragonQuestino/game_input.c
+++ b/DragonQuestino/game_input.c
@@ -190,7 +190,7 @@ internal void Game_HandleMenuInput( Game_t* game )
 
       switch ( game->menu.items[game->menu.selectedIndex].command )
       {
-         case MenuCommand_OverworldMain_Talk: Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Talk_NobodyThere ); break;
+         case MenuCommand_OverworldMain_Talk: Game_OpenScrollingDialog( game, DialogMessageId_Talk_NobodyThere ); break;
          case MenuCommand_OverworldMain_Status:
             Game_DrawOverworldDeepStatus( game );
             Game_ChangeState( game, GameState_Overworld_Waiting );
@@ -254,7 +254,7 @@ internal void Game_OpenOverworldSpellMenu( Game_t* game )
 {
    if ( !game->player.spells )
    {
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Spell_None );
+      Game_OpenScrollingDialog( game, DialogMessageId_Spell_None );
    }
    else if ( SPELL_GET_MAPUSEABLECOUNT( game->player.spells, game->tileMap.isDungeon, game->tileMap.isDark ) )
    {
@@ -262,7 +262,7 @@ internal void Game_OpenOverworldSpellMenu( Game_t* game )
    }
    else
    {
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Spell_OverworldCantCast );
+      Game_OpenScrollingDialog( game, DialogMessageId_Spell_OverworldCantCast );
    }
 }
 
@@ -273,7 +273,7 @@ internal void Game_OpenOverworldItemMenu( Game_t* game )
 
    if ( useableCount == 0 && nonUseableCount == 0 )
    {
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Item_None );
+      Game_OpenScrollingDialog( game, DialogMessageId_Item_None );
    }
    else
    {
@@ -299,7 +299,7 @@ internal void Game_OpenZoomMenu( Game_t* game )
 
    if ( game->player.stats.magicPoints < SPELL_ZOOM_MP )
    {
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Spell_NotEnoughMp );
+      Game_OpenScrollingDialog( game, DialogMessageId_Spell_NotEnoughMp );
    }
    else if ( townCount > 0 )
    {

--- a/DragonQuestino/game_items.c
+++ b/DragonQuestino/game_items.c
@@ -4,7 +4,7 @@ void Game_UseHerb( Game_t* game )
 {
    if ( game->player.stats.hitPoints == game->player.stats.maxHitPoints )
    {
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_FullyHealed );
+      Game_OpenScrollingDialog( game, DialogMessageId_FullyHealed );
    }
    else
    {
@@ -17,13 +17,13 @@ void Game_UseWing( Game_t* game )
 {
    if ( game->tileMap.isDungeon )
    {
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Use_WingCantUse );
+      Game_OpenScrollingDialog( game, DialogMessageId_Use_WingCantUse );
    }
    else
    {
       ITEM_SET_WINGCOUNT( game->player.items, ITEM_GET_WINGCOUNT( game->player.items ) - 1 );
       game->targetPortal = &( game->zoomPortals[TILEMAP_TANTEGEL_TOWN_ID] );
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Use_Wing );
+      Game_OpenScrollingDialog( game, DialogMessageId_Use_Wing );
    }
 }
 
@@ -33,12 +33,12 @@ void Game_UseFairyWater( Game_t* game )
 
    if ( game->player.isCursed )
    {
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Use_FairyWaterCursed );
+      Game_OpenScrollingDialog( game, DialogMessageId_Use_FairyWaterCursed );
    }
    else
    {
       Player_SetHolyProtection( &( game->player ), True );
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Use_FairyWater );
+      Game_OpenScrollingDialog( game, DialogMessageId_Use_FairyWater );
    }
 }
 
@@ -54,22 +54,22 @@ void Game_UseTorch( Game_t* game )
       }
 
       ITEM_SET_TORCHCOUNT( game->player.items, ITEM_GET_TORCHCOUNT( game->player.items ) - 1 );
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Use_Torch );
+      Game_OpenScrollingDialog( game, DialogMessageId_Use_Torch );
    }
    else
    {
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Use_TorchCantUse );
+      Game_OpenScrollingDialog( game, DialogMessageId_Use_TorchCantUse );
    }
 }
 
 void Game_UseSilverHarp( Game_t* game )
 {
-   Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Use_SilverHarp );
+   Game_OpenScrollingDialog( game, DialogMessageId_Use_SilverHarp );
 }
 
 void Game_UseFairyFlute( Game_t* game )
 {
-   Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Use_FairyFlute );
+   Game_OpenScrollingDialog( game, DialogMessageId_Use_FairyFlute );
 }
 
 void Game_UseGwaelynsLove( Game_t* game )
@@ -102,11 +102,11 @@ void Game_UseGwaelynsLove( Game_t* game )
       }
 
       ScrollingDialog_SetInsertionText( &( game->scrollingDialog ), msg );
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Use_GwaelynsLove );
+      Game_OpenScrollingDialog( game, DialogMessageId_Use_GwaelynsLove );
    }
    else
    {
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Use_GwaelynsLoveCantUse );
+      Game_OpenScrollingDialog( game, DialogMessageId_Use_GwaelynsLoveCantUse );
    }
 }
 
@@ -116,16 +116,16 @@ void Game_UseRainbowDrop( Game_t* game )
         game->player.tileIndex == ( TILEMAP_RAINBOWBRIDGE_INDEX + 1 ) &&
         game->player.sprite.direction == Direction_Left )
    {
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Use_RainbowDrop );
+      Game_OpenScrollingDialog( game, DialogMessageId_Use_RainbowDrop );
    }
    else
    {
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Use_RainbowDropCantUse );
+      Game_OpenScrollingDialog( game, DialogMessageId_Use_RainbowDropCantUse );
    }
 }
 
 void Game_UseCursedBelt( Game_t* game )
 {
    ITEM_TOGGLE_HASCURSEDBELT( game->player.items );
-   Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Use_CursedBelt );
+   Game_OpenScrollingDialog( game, DialogMessageId_Use_CursedBelt );
 }

--- a/DragonQuestino/game_physics.c
+++ b/DragonQuestino/game_physics.c
@@ -171,7 +171,7 @@ void Game_PlayerSteppedOnTile( Game_t* game, uint32_t tileIndex )
       if ( game->player.holyProtectionSteps >= HOLY_PROTECTION_MAX_STEPS )
       {
          game->player.hasHolyProtection = False;
-         Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_HolyProtection_Off );
+         Game_OpenScrollingDialog( game, DialogMessageId_HolyProtection_Off );
       }
    }
 }

--- a/DragonQuestino/game_spells.c
+++ b/DragonQuestino/game_spells.c
@@ -13,7 +13,7 @@ void Game_CastHeal( Game_t* game )
 
    if ( game->player.stats.hitPoints == UINT8_MAX )
    {
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_FullyHealed );
+      Game_OpenScrollingDialog( game, DialogMessageId_FullyHealed );
    }
    else
    {
@@ -37,7 +37,7 @@ void Game_CastGlow( Game_t* game )
       if ( game->player.isCursed )
       {
          TileMap_SetTargetGlowDiameter( &( game->tileMap ), 1 );
-         Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Spell_OverworldCastGlowCursed );
+         Game_OpenScrollingDialog( game, DialogMessageId_Spell_OverworldCastGlowCursed );
       }
       else
       {
@@ -48,7 +48,7 @@ void Game_CastGlow( Game_t* game )
             TileMap_StartGlowTransition( &( game->tileMap ) );
          }
 
-         Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Spell_OverworldCastGlow );
+         Game_OpenScrollingDialog( game, DialogMessageId_Spell_OverworldCastGlow );
       }
    }
 }
@@ -64,11 +64,11 @@ void Game_CastEvac( Game_t* game )
 
       if ( game->player.isCursed )
       {
-         Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Spell_CastEvacCursed );
+         Game_OpenScrollingDialog( game, DialogMessageId_Spell_CastEvacCursed );
       }
       else
       {
-         Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Spell_CastEvac );
+         Game_OpenScrollingDialog( game, DialogMessageId_Spell_CastEvac );
       }
    }
 }
@@ -80,7 +80,7 @@ void Game_CastZoom( Game_t* game, uint32_t townId )
    game->player.stats.magicPoints -= SPELL_ZOOM_MP;
    game->targetPortal = &( game->zoomPortals[townId] );
    Game_DrawOverworldQuickStatus( game );
-   Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Spell_CastZoom );
+   Game_OpenScrollingDialog( game, DialogMessageId_Spell_CastZoom );
 }
 
 void Game_CastRepel( Game_t* game )
@@ -92,12 +92,12 @@ void Game_CastRepel( Game_t* game )
 
    if ( game->player.isCursed )
    {
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Spell_CastRepelCursed );
+      Game_OpenScrollingDialog( game, DialogMessageId_Spell_CastRepelCursed );
    }
    else
    {
       Player_SetHolyProtection( &( game->player ), True );
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Spell_CastRepel );
+      Game_OpenScrollingDialog( game, DialogMessageId_Spell_CastRepel );
    }
 }
 
@@ -109,7 +109,7 @@ void Game_CastMidheal( Game_t* game )
 
    if ( game->player.stats.hitPoints == UINT8_MAX )
    {
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_FullyHealed );
+      Game_OpenScrollingDialog( game, DialogMessageId_FullyHealed );
    }
    else
    {
@@ -125,7 +125,7 @@ internal Bool_t Game_CanCastSpell( Game_t* game, uint8_t requiredMp, const char*
 {
    if ( game->player.stats.magicPoints < requiredMp )
    {
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Spell_NotEnoughMp );
+      Game_OpenScrollingDialog( game, DialogMessageId_Spell_NotEnoughMp );
       return False;
    }
    else if ( game->tileMap.blocksMagic )
@@ -133,7 +133,7 @@ internal Bool_t Game_CanCastSpell( Game_t* game, uint8_t requiredMp, const char*
       game->player.stats.magicPoints -= requiredMp;
       Game_DrawOverworldQuickStatus( game );
       ScrollingDialog_SetInsertionText( &( game->scrollingDialog ), spellName );
-      Game_OpenScrollingDialog( game, ScrollingDialogType_Overworld, DialogMessageId_Spell_Blocked );
+      Game_OpenScrollingDialog( game, DialogMessageId_Spell_Blocked );
       return False;
    }
 

--- a/DragonQuestino/scrolling_dialog.c
+++ b/DragonQuestino/scrolling_dialog.c
@@ -5,8 +5,6 @@
 
 internal void ScrollingDialog_ResetScroll( ScrollingDialog_t* dialog );
 internal void ScrollingDialog_LoadMessage( ScrollingDialog_t* dialog );
-internal void ScrollingDialog_LoadType( ScrollingDialog_t* dialog, ScrollingDialogType_t type );
-internal void ScrollingDialog_LoadOverworldType( ScrollingDialog_t* dialog );
 internal uint32_t ScrollingDialog_GetMessageSectionCount( DialogMessageId_t messageId );
 internal void ScrollingDialog_GetMessageText( ScrollingDialog_t* dialog, char* text );
 
@@ -16,12 +14,16 @@ void ScrollingDialog_Init( ScrollingDialog_t* dialog, Screen_t* screen, Player_t
    dialog->player = player;
 }
 
-void ScrollingDialog_Load( ScrollingDialog_t* dialog, ScrollingDialogType_t type, DialogMessageId_t messageId )
+void ScrollingDialog_Load( ScrollingDialog_t* dialog, DialogMessageId_t messageId )
 {
    dialog->messageId = messageId;
    dialog->section = 0;
+   dialog->position.x = 32;
+   dialog->position.y = 144;
+   dialog->size.x = 24;
+   dialog->size.y = 8;
+   dialog->lineWidth = 22;
 
-   ScrollingDialog_LoadType( dialog, type );
    ScrollingDialog_LoadMessage( dialog );
    ScrollingDialog_ResetScroll( dialog );
 }
@@ -201,25 +203,6 @@ internal void ScrollingDialog_LoadMessage( ScrollingDialog_t* dialog )
          lastSpaceIndex = lineIndex;
       }
    }
-}
-
-internal void ScrollingDialog_LoadType( ScrollingDialog_t* dialog, ScrollingDialogType_t type )
-{
-   switch ( type )
-   {
-      case ScrollingDialogType_Overworld:
-         ScrollingDialog_LoadOverworldType( dialog );
-         break;
-   }
-}
-
-internal void ScrollingDialog_LoadOverworldType( ScrollingDialog_t* dialog )
-{
-   dialog->position.x = 32;
-   dialog->position.y = 144;
-   dialog->size.x = 24;
-   dialog->size.y = 8;
-   dialog->lineWidth = 22;
 }
 
 internal uint32_t ScrollingDialog_GetMessageSectionCount( DialogMessageId_t messageId )

--- a/DragonQuestino/scrolling_dialog.h
+++ b/DragonQuestino/scrolling_dialog.h
@@ -44,7 +44,7 @@ extern "C" {
 #endif
 
 void ScrollingDialog_Init( ScrollingDialog_t* dialog, Screen_t* screen, Player_t* player );
-void ScrollingDialog_Load( ScrollingDialog_t* dialog, ScrollingDialogType_t type, DialogMessageId_t messageId );
+void ScrollingDialog_Load( ScrollingDialog_t* dialog, DialogMessageId_t messageId );
 void ScrollingDialog_SetInsertionText( ScrollingDialog_t* dialog, const char* text );
 void ScrollingDialog_Draw( ScrollingDialog_t* dialog );
 Bool_t ScrollingDialog_Next( ScrollingDialog_t* dialog );


### PR DESCRIPTION
## Overview

This just removes the `ScrollingDialogType_t` enum, because I don't think we're gonna need it. The dialog will most likely be in the same place during battle, it's just easier without it.