### PR TITLE
Refactor: game states, menus and rendering

### DIFF
--- a/DragonQuestino/dialog.c
+++ b/DragonQuestino/dialog.c
@@ -1,22 +1,22 @@
-#include "scrolling_dialog.h"
+#include "dialog.h"
 #include "screen.h"
 #include "player.h"
 #include "clock.h"
 
-internal void ScrollingDialog_ResetScroll( ScrollingDialog_t* dialog );
-internal void ScrollingDialog_LoadMessage( ScrollingDialog_t* dialog );
-internal uint32_t ScrollingDialog_GetMessageSectionCount( DialogMessageId_t messageId );
-internal void ScrollingDialog_GetMessageText( ScrollingDialog_t* dialog, char* text );
+internal void Dialog_ResetScroll( Dialog_t* dialog );
+internal void Dialog_LoadMessage( Dialog_t* dialog );
+internal uint32_t Dialog_GetMessageSectionCount( DialogId_t id );
+internal void Dialog_GetMessageText( Dialog_t* dialog, char* text );
 
-void ScrollingDialog_Init( ScrollingDialog_t* dialog, Screen_t* screen, Player_t* player )
+void Dialog_Init( Dialog_t* dialog, Screen_t* screen, Player_t* player )
 {
    dialog->screen = screen;
    dialog->player = player;
 }
 
-void ScrollingDialog_Load( ScrollingDialog_t* dialog, DialogMessageId_t messageId )
+void Dialog_Load( Dialog_t* dialog, DialogId_t id )
 {
-   dialog->messageId = messageId;
+   dialog->id = id;
    dialog->section = 0;
    dialog->position.x = 32;
    dialog->position.y = 144;
@@ -24,16 +24,16 @@ void ScrollingDialog_Load( ScrollingDialog_t* dialog, DialogMessageId_t messageI
    dialog->size.y = 8;
    dialog->lineWidth = 22;
 
-   ScrollingDialog_LoadMessage( dialog );
-   ScrollingDialog_ResetScroll( dialog );
+   Dialog_LoadMessage( dialog );
+   Dialog_ResetScroll( dialog );
 }
 
-void ScrollingDialog_SetInsertionText( ScrollingDialog_t* dialog, const char* text )
+void Dialog_SetInsertionText( Dialog_t* dialog, const char* text )
 {
    strcpy( dialog->insertionText, text );
 }
 
-void ScrollingDialog_Draw( ScrollingDialog_t* dialog )
+void Dialog_Draw( Dialog_t* dialog )
 {
    uint32_t i, x, y, stopCharIndex, len;
    char substr[DIALOG_MAX_LINE_CHARS];
@@ -72,14 +72,14 @@ void ScrollingDialog_Draw( ScrollingDialog_t* dialog )
          Screen_DrawText( dialog->screen, dialog->lines[i], x, y );
       }
 
-      if ( dialog->showCarat && !ScrollingDialog_IsDone( dialog ) )
+      if ( dialog->showCarat && !Dialog_IsDone( dialog ) )
       {
          Screen_DrawChar( dialog->screen, DOWNWARD_CARAT, x + ( ( dialog->lineWidth / 2 ) * TEXT_TILE_SIZE ), y );
       }
    }
 }
 
-Bool_t ScrollingDialog_Next( ScrollingDialog_t* dialog )
+Bool_t Dialog_Next( Dialog_t* dialog )
 {
    if ( dialog->isScrolling )
    {
@@ -87,21 +87,21 @@ Bool_t ScrollingDialog_Next( ScrollingDialog_t* dialog )
    }
    else if ( dialog->section < ( dialog->sectionCount - 1 ) )
    {
-      ScrollingDialog_Skip( dialog );
+      Dialog_Skip( dialog );
       return True;
    }
 
    return False;
 }
 
-void ScrollingDialog_Skip( ScrollingDialog_t* dialog )
+void Dialog_Skip( Dialog_t* dialog )
 {
    dialog->section++;
-   ScrollingDialog_LoadMessage( dialog );
-   ScrollingDialog_ResetScroll( dialog );
+   Dialog_LoadMessage( dialog );
+   Dialog_ResetScroll( dialog );
 }
 
-void ScrollingDialog_Tic( ScrollingDialog_t* dialog )
+void Dialog_Tic( Dialog_t* dialog )
 {
    if ( dialog->isScrolling )
    {
@@ -112,7 +112,7 @@ void ScrollingDialog_Tic( ScrollingDialog_t* dialog )
          dialog->isScrolling = False;
       }
    }
-   else if ( !ScrollingDialog_IsDone( dialog ) )
+   else if ( !Dialog_IsDone( dialog ) )
    {
       dialog->blinkSeconds += CLOCK_FRAME_SECONDS;
 
@@ -124,12 +124,12 @@ void ScrollingDialog_Tic( ScrollingDialog_t* dialog )
    }
 }
 
-Bool_t ScrollingDialog_IsDone( ScrollingDialog_t* dialog )
+Bool_t Dialog_IsDone( Dialog_t* dialog )
 {
    return ( !dialog->isScrolling && ( dialog->section >= ( dialog->sectionCount - 1 ) ) ) ? True : False;
 }
 
-internal void ScrollingDialog_ResetScroll( ScrollingDialog_t* dialog )
+internal void Dialog_ResetScroll( Dialog_t* dialog )
 {
    dialog->isScrolling = True;
    dialog->scrollSeconds = 0.0f;
@@ -138,7 +138,7 @@ internal void ScrollingDialog_ResetScroll( ScrollingDialog_t* dialog )
    dialog->blinkSeconds = 0.0f;
 }
 
-internal void ScrollingDialog_LoadMessage( ScrollingDialog_t* dialog )
+internal void Dialog_LoadMessage( Dialog_t* dialog )
 {
    uint32_t textIndex, lineIndex, lastSpaceIndex, currentLine;
    uint32_t strLen;
@@ -147,9 +147,9 @@ internal void ScrollingDialog_LoadMessage( ScrollingDialog_t* dialog )
 
    dialog->lineCount = 0;
    dialog->charCount = 0;
-   dialog->sectionCount = ScrollingDialog_GetMessageSectionCount( dialog->messageId );
+   dialog->sectionCount = Dialog_GetMessageSectionCount( dialog->id );
 
-   ScrollingDialog_GetMessageText( dialog, message );
+   Dialog_GetMessageText( dialog, message );
    strLen = (uint16_t)strlen( message );
 
    for ( textIndex = 0, lineIndex = 0, lastSpaceIndex = 0, currentLine = 0; textIndex < strLen; textIndex++ )
@@ -205,167 +205,167 @@ internal void ScrollingDialog_LoadMessage( ScrollingDialog_t* dialog )
    }
 }
 
-internal uint32_t ScrollingDialog_GetMessageSectionCount( DialogMessageId_t messageId )
+internal uint32_t Dialog_GetMessageSectionCount( DialogId_t id )
 {
-   switch ( messageId )
+   switch ( id )
    {
-      case DialogMessageId_Talk_NobodyThere:
-      case DialogMessageId_Spell_None:
-      case DialogMessageId_Spell_OverworldCantCast:
-      case DialogMessageId_Spell_OverworldCastGlow:
-      case DialogMessageId_Spell_CastEvac:
-      case DialogMessageId_Spell_CastZoom:
-      case DialogMessageId_Spell_NotEnoughMp:
-      case DialogMessageId_Item_None:
-      case DialogMessageId_Door_None:
-      case DialogMessageId_Door_NoKeys:
-      case DialogMessageId_FullyHealed:
-      case DialogMessageId_HolyProtection_Off:
-      case DialogMessageId_Use_WingCantUse:
-      case DialogMessageId_Use_Wing:
-      case DialogMessageId_Use_TorchCantUse:
-      case DialogMessageId_Use_Torch:
-      case DialogMessageId_Use_GwaelynsLoveCantUse:
-      case DialogMessageId_Use_RainbowDropCantUse:
-      case DialogMessageId_Use_RainbowDrop:
-      case DialogMessageId_Chest_ItemCollected:
-      case DialogMessageId_Chest_GoldCollected:
+      case DialogId_Talk_NobodyThere:
+      case DialogId_Spell_None:
+      case DialogId_Spell_OverworldCantCast:
+      case DialogId_Spell_OverworldCastGlow:
+      case DialogId_Spell_CastEvac:
+      case DialogId_Spell_CastZoom:
+      case DialogId_Spell_NotEnoughMp:
+      case DialogId_Item_None:
+      case DialogId_Door_None:
+      case DialogId_Door_NoKeys:
+      case DialogId_FullyHealed:
+      case DialogId_HolyProtection_Off:
+      case DialogId_Use_WingCantUse:
+      case DialogId_Use_Wing:
+      case DialogId_Use_TorchCantUse:
+      case DialogId_Use_Torch:
+      case DialogId_Use_GwaelynsLoveCantUse:
+      case DialogId_Use_RainbowDropCantUse:
+      case DialogId_Use_RainbowDrop:
+      case DialogId_Chest_ItemCollected:
+      case DialogId_Chest_GoldCollected:
          return 1;
-      case DialogMessageId_Search_NothingFound:
-      case DialogMessageId_Search_FoundItem:
-      case DialogMessageId_Search_FoundHiddenStairs:
-      case DialogMessageId_Use_Herb1:
-      case DialogMessageId_Use_Herb2:
-      case DialogMessageId_Use_FairyWaterCursed:
-      case DialogMessageId_Use_FairyWater:
-      case DialogMessageId_Use_FairyFlute:
-      case DialogMessageId_Use_SilverHarp:
-      case DialogMessageId_Use_CursedBelt:
-      case DialogMessageId_Spell_OverworldCastGlowCursed:
-      case DialogMessageId_Spell_CastRepelCursed:
-      case DialogMessageId_Spell_CastRepel:
-      case DialogMessageId_Spell_CastEvacCursed:
-      case DialogMessageId_Chest_ItemNoSpace:
-      case DialogMessageId_Chest_GoldNoSpace:
-      case DialogMessageId_Chest_DeathNecklace:
-      case DialogMessageId_Spell_OverworldCastHeal1:
-      case DialogMessageId_Spell_OverworldCastHeal2:
-      case DialogMessageId_Spell_OverworldCastMidheal1:
-      case DialogMessageId_Spell_OverworldCastMidheal2:
-      case DialogMessageId_Spell_Blocked:
+      case DialogId_Search_NothingFound:
+      case DialogId_Search_FoundItem:
+      case DialogId_Search_FoundHiddenStairs:
+      case DialogId_Use_Herb1:
+      case DialogId_Use_Herb2:
+      case DialogId_Use_FairyWaterCursed:
+      case DialogId_Use_FairyWater:
+      case DialogId_Use_FairyFlute:
+      case DialogId_Use_SilverHarp:
+      case DialogId_Use_CursedBelt:
+      case DialogId_Spell_OverworldCastGlowCursed:
+      case DialogId_Spell_CastRepelCursed:
+      case DialogId_Spell_CastRepel:
+      case DialogId_Spell_CastEvacCursed:
+      case DialogId_Chest_ItemNoSpace:
+      case DialogId_Chest_GoldNoSpace:
+      case DialogId_Chest_DeathNecklace:
+      case DialogId_Spell_OverworldCastHeal1:
+      case DialogId_Spell_OverworldCastHeal2:
+      case DialogId_Spell_OverworldCastMidheal1:
+      case DialogId_Spell_OverworldCastMidheal2:
+      case DialogId_Spell_Blocked:
          return 2;
-      case DialogMessageId_Use_GwaelynsLove:
+      case DialogId_Use_GwaelynsLove:
          return 4;
-      case DialogMessageId_Chest_Tablet:
+      case DialogId_Chest_Tablet:
          return 8;
    }
 
    return 0;
 }
 
-internal void ScrollingDialog_GetMessageText( ScrollingDialog_t* dialog, char* text )
+internal void Dialog_GetMessageText( Dialog_t* dialog, char* text )
 {
    uint32_t e;
    Player_t* player = dialog->player;
 
-   switch ( dialog->messageId )
+   switch ( dialog->id )
    {
-      case DialogMessageId_Talk_NobodyThere: strcpy( text, STRING_OVERWORLD_DIALOG_NOBODY_THERE ); return;
-      case DialogMessageId_Search_NothingFound:
+      case DialogId_Talk_NobodyThere: strcpy( text, STRING_OVERWORLD_DIALOG_NOBODY_THERE ); return;
+      case DialogId_Search_NothingFound:
          switch ( dialog->section )
          {
             case 0: strcpy( text, STRING_OVERWORLD_DIALOG_SEARCH ); return;
             case 1: strcpy( text, STRING_OVERWORLD_DIALOG_SEARCH_NOT_FOUND ); return;
          }
-      case DialogMessageId_Search_FoundItem:
+      case DialogId_Search_FoundItem:
          switch ( dialog->section )
          {
             case 0: strcpy( text, STRING_OVERWORLD_DIALOG_SEARCH ); return;
             case 1: sprintf( text, STRING_OVERWORLD_DIALOG_SEARCH_FOUND, dialog->insertionText ); return;
          }
-      case DialogMessageId_Search_FoundHiddenStairs:
+      case DialogId_Search_FoundHiddenStairs:
          switch ( dialog->section )
          {
             case 0: strcpy( text, STRING_OVERWORLD_DIALOG_SEARCH ); return;
             case 1: strcpy( text, STRING_FOUND_HIDDENSTAIRS ); return;
          }
-      case DialogMessageId_Spell_None: strcpy( text, STRING_OVERWORLD_DIALOG_NO_SPELLS ); return;
-      case DialogMessageId_Spell_OverworldCantCast: strcpy( text, STRING_OVERWORLD_DIALOG_SPELLS_OVERWORLD_CANT_CAST ); return;
-      case DialogMessageId_Spell_OverworldCastGlow: sprintf( text, STRING_OVERWORLD_DIALOG_SPELLS_OVERWORLD_CAST, STRING_SPELLMENU_GLOW ); return;
-      case DialogMessageId_Spell_OverworldCastGlowCursed:
+      case DialogId_Spell_None: strcpy( text, STRING_OVERWORLD_DIALOG_NO_SPELLS ); return;
+      case DialogId_Spell_OverworldCantCast: strcpy( text, STRING_OVERWORLD_DIALOG_SPELLS_OVERWORLD_CANT_CAST ); return;
+      case DialogId_Spell_OverworldCastGlow: sprintf( text, STRING_OVERWORLD_DIALOG_SPELLS_OVERWORLD_CAST, STRING_SPELLMENU_GLOW ); return;
+      case DialogId_Spell_OverworldCastGlowCursed:
          switch ( dialog->section )
          {
             case 0: sprintf( text, STRING_OVERWORLD_DIALOG_SPELLS_OVERWORLD_CAST, STRING_SPELLMENU_GLOW ); return;
             case 1: strcpy( text, STRING_GLOW_CURSED ); return;
          }
-      case DialogMessageId_Spell_CastRepelCursed:
+      case DialogId_Spell_CastRepelCursed:
          switch ( dialog->section )
          {
             case 0: sprintf( text, STRING_OVERWORLD_DIALOG_SPELLS_OVERWORLD_CAST, STRING_SPELLMENU_REPEL ); return;
             case 1: strcpy( text, STRING_HOLYPROTECTION_CURSED ); return;
          }
-      case DialogMessageId_Spell_CastEvacCursed:
+      case DialogId_Spell_CastEvacCursed:
          switch ( dialog->section )
          {
             case 0: sprintf( text, STRING_OVERWORLD_DIALOG_SPELLS_OVERWORLD_CAST, STRING_SPELLMENU_EVAC ); return;
             case 1: strcpy( text, STRING_EVAC_CURSED ); return;
          }
-      case DialogMessageId_Spell_CastRepel:
+      case DialogId_Spell_CastRepel:
          switch ( dialog->section )
          {
             case 0: sprintf( text, STRING_OVERWORLD_DIALOG_SPELLS_OVERWORLD_CAST, STRING_SPELLMENU_REPEL ); return;
             case 1: strcpy( text, STRING_HOLYPROTECTION_ON ); return;
          }
-      case DialogMessageId_Spell_CastEvac: sprintf( text, STRING_OVERWORLD_DIALOG_SPELLS_OVERWORLD_CAST, STRING_SPELLMENU_EVAC ); return;
-      case DialogMessageId_Spell_CastZoom: sprintf( text, STRING_OVERWORLD_DIALOG_SPELLS_OVERWORLD_CAST, STRING_SPELLMENU_ZOOM ); return;
-      case DialogMessageId_Spell_NotEnoughMp: strcpy( text, STRING_NOTENOUGHMP ); return;
-      case DialogMessageId_Item_None: strcpy( text, STRING_OVERWORLD_DIALOG_NO_ITEMS ); return;
-      case DialogMessageId_Door_None: strcpy( text, STRING_OVERWORLD_DIALOG_NO_DOOR ); return;
-      case DialogMessageId_Door_NoKeys: strcpy( text, STRING_OVERWORLD_DIALOG_NO_KEYS ); return;
-      case DialogMessageId_FullyHealed: strcpy( text, STRING_FULLYHEALED ); return;
-      case DialogMessageId_HolyProtection_Off: strcpy( text, STRING_HOLYPROTECTION_OFF ); return;
-      case DialogMessageId_Use_Herb1:
+      case DialogId_Spell_CastEvac: sprintf( text, STRING_OVERWORLD_DIALOG_SPELLS_OVERWORLD_CAST, STRING_SPELLMENU_EVAC ); return;
+      case DialogId_Spell_CastZoom: sprintf( text, STRING_OVERWORLD_DIALOG_SPELLS_OVERWORLD_CAST, STRING_SPELLMENU_ZOOM ); return;
+      case DialogId_Spell_NotEnoughMp: strcpy( text, STRING_NOTENOUGHMP ); return;
+      case DialogId_Item_None: strcpy( text, STRING_OVERWORLD_DIALOG_NO_ITEMS ); return;
+      case DialogId_Door_None: strcpy( text, STRING_OVERWORLD_DIALOG_NO_DOOR ); return;
+      case DialogId_Door_NoKeys: strcpy( text, STRING_OVERWORLD_DIALOG_NO_KEYS ); return;
+      case DialogId_FullyHealed: strcpy( text, STRING_FULLYHEALED ); return;
+      case DialogId_HolyProtection_Off: strcpy( text, STRING_HOLYPROTECTION_OFF ); return;
+      case DialogId_Use_Herb1:
          switch ( dialog->section )
          {
             case 0: strcpy( text, STRING_ITEMUSE_HERB ); return;
             case 1: sprintf( text, STRING_OVERWORLD_DIALOG_HEAL_RESULT_1, dialog->insertionText ); return;
          }
-      case DialogMessageId_Use_Herb2:
+      case DialogId_Use_Herb2:
          switch ( dialog->section )
          {
             case 0: strcpy( text, STRING_ITEMUSE_HERB ); return;
             case 1: sprintf( text, STRING_OVERWORLD_DIALOG_HEAL_RESULT_2, dialog->insertionText ); return;
          }
-      case DialogMessageId_Use_Wing: strcpy( text, STRING_ITEMUSE_WING ); return;
-      case DialogMessageId_Use_FairyWaterCursed:
+      case DialogId_Use_Wing: strcpy( text, STRING_ITEMUSE_WING ); return;
+      case DialogId_Use_FairyWaterCursed:
          switch ( dialog->section )
          {
             case 0: strcpy( text, STRING_ITEMUSE_FAIRYWATER ); return;
             case 1: strcpy( text, STRING_HOLYPROTECTION_CURSED ); return;
          }
-      case DialogMessageId_Use_FairyWater:
+      case DialogId_Use_FairyWater:
          switch ( dialog->section )
          {
             case 0: strcpy( text, STRING_ITEMUSE_FAIRYWATER ); return;
             case 1: strcpy( text, STRING_HOLYPROTECTION_ON ); return;
          }
-      case DialogMessageId_Use_WingCantUse: strcpy( text, STRING_ITEMUSE_WING_CANTUSE ); return;
-      case DialogMessageId_Use_TorchCantUse: strcpy( text, STRING_ITEMUSE_TORCH_CANTUSE ); return;
-      case DialogMessageId_Use_Torch: strcpy( text, STRING_ITEMUSE_TORCH ); return;
-      case DialogMessageId_Use_FairyFlute:
+      case DialogId_Use_WingCantUse: strcpy( text, STRING_ITEMUSE_WING_CANTUSE ); return;
+      case DialogId_Use_TorchCantUse: strcpy( text, STRING_ITEMUSE_TORCH_CANTUSE ); return;
+      case DialogId_Use_Torch: strcpy( text, STRING_ITEMUSE_TORCH ); return;
+      case DialogId_Use_FairyFlute:
          switch ( dialog->section )
          {
             case 0: strcpy( text, STRING_ITEMUSE_FAIRYFLUTE_1 ); return;
             case 1: strcpy( text, STRING_ITEMUSE_FAIRYFLUTE_2 ); return;
          }
-      case DialogMessageId_Use_SilverHarp:
+      case DialogId_Use_SilverHarp:
          switch ( dialog->section )
          {
             case 0: strcpy( text, STRING_ITEMUSE_SILVERHARP_1 ); return;
             case 1: strcpy( text, STRING_ITEMUSE_SILVERHARP_2 ); return;
          }
-      case DialogMessageId_Use_GwaelynsLoveCantUse: strcpy( text, STRING_ITEMUSE_GWAELINSLOVE_CANTUSE ); return;
-      case DialogMessageId_Use_GwaelynsLove:
+      case DialogId_Use_GwaelynsLoveCantUse: strcpy( text, STRING_ITEMUSE_GWAELINSLOVE_CANTUSE ); return;
+      case DialogId_Use_GwaelynsLove:
          switch ( dialog->section )
          {
             case 0: sprintf( text, STRING_ITEMUSE_GWAELINSLOVE_1, player->name ); return;
@@ -376,29 +376,29 @@ internal void ScrollingDialog_GetMessageText( ScrollingDialog_t* dialog, char* t
             case 2: sprintf( text, STRING_ITEMUSE_GWAELINSLOVE_3, dialog->insertionText ); return;
             case 3: sprintf( text, STRING_ITEMUSE_GWAELINSLOVE_4, player->name ); return;
          }
-      case DialogMessageId_Use_RainbowDropCantUse: strcpy( text, STRING_ITEMUSE_RAINBOWDROP_CANTUSE ); return;
-      case DialogMessageId_Use_RainbowDrop: strcpy( text, STRING_ITEMUSE_RAINBOWDROP ); return;
-      case DialogMessageId_Use_CursedBelt:
+      case DialogId_Use_RainbowDropCantUse: strcpy( text, STRING_ITEMUSE_RAINBOWDROP_CANTUSE ); return;
+      case DialogId_Use_RainbowDrop: strcpy( text, STRING_ITEMUSE_RAINBOWDROP ); return;
+      case DialogId_Use_CursedBelt:
          switch ( dialog->section )
          {
             case 0: strcpy( text, STRING_ITEMUSE_CURSEDBELT ); return;
             case 1: strcpy( text, STRING_CURSED ); return;
          }
-      case DialogMessageId_Chest_ItemCollected: sprintf( text, STRING_CHEST_ITEMFOUND, dialog->insertionText ); return;
-      case DialogMessageId_Chest_ItemNoSpace:
+      case DialogId_Chest_ItemCollected: sprintf( text, STRING_CHEST_ITEMFOUND, dialog->insertionText ); return;
+      case DialogId_Chest_ItemNoSpace:
          switch ( dialog->section )
          {
             case 0: sprintf( text, STRING_CHEST_ITEMFOUND, dialog->insertionText ); return;
             case 1: strcpy( text, STRING_CHEST_ITEMNOSPACE ); return;
          }
-      case DialogMessageId_Chest_GoldCollected: sprintf( text, STRING_CHEST_GOLDFOUND, dialog->insertionText ); return;
-      case DialogMessageId_Chest_GoldNoSpace:
+      case DialogId_Chest_GoldCollected: sprintf( text, STRING_CHEST_GOLDFOUND, dialog->insertionText ); return;
+      case DialogId_Chest_GoldNoSpace:
          switch ( dialog->section )
          {
             case 0: sprintf( text, STRING_CHEST_GOLDFOUND, dialog->insertionText ); return;
             case 1: strcpy( text, STRING_CHEST_GOLDNOSPACE ); return;
          }
-      case DialogMessageId_Chest_Tablet:
+      case DialogId_Chest_Tablet:
          switch ( dialog->section )
          {
             case 0: sprintf( text, STRING_CHEST_ITEMFOUND, STRING_CHESTCOLLECT_TABLET ); return;
@@ -410,37 +410,37 @@ internal void ScrollingDialog_GetMessageText( ScrollingDialog_t* dialog, char* t
             case 6: strcpy( text, STRING_CHEST_TABLET_6 ); return;
             case 7: strcpy( text, STRING_CHEST_TABLET_7 ); return;
          }
-      case DialogMessageId_Chest_DeathNecklace:
+      case DialogId_Chest_DeathNecklace:
          switch ( dialog->section )
          {
             case 0: sprintf( text, STRING_CHEST_ITEMFOUND, STRING_CHESTCOLLECT_DEATHNECKLACE ); return;
             case 1: strcpy( text, STRING_CURSED ); return;
          }
-      case DialogMessageId_Spell_OverworldCastHeal1:
+      case DialogId_Spell_OverworldCastHeal1:
          switch ( dialog->section )
          {
             case 0: sprintf( text, STRING_OVERWORLD_DIALOG_SPELLS_OVERWORLD_CAST, STRING_SPELLMENU_HEAL ); return;
             case 1: sprintf( text, STRING_OVERWORLD_DIALOG_HEAL_RESULT_1, dialog->insertionText ); return;
          }
-      case DialogMessageId_Spell_OverworldCastHeal2:
+      case DialogId_Spell_OverworldCastHeal2:
          switch ( dialog->section )
          {
             case 0: sprintf( text, STRING_OVERWORLD_DIALOG_SPELLS_OVERWORLD_CAST, STRING_SPELLMENU_HEAL ); return;
             case 1: sprintf( text, STRING_OVERWORLD_DIALOG_HEAL_RESULT_2, dialog->insertionText ); return;
          }
-      case DialogMessageId_Spell_OverworldCastMidheal1:
+      case DialogId_Spell_OverworldCastMidheal1:
          switch ( dialog->section )
          {
             case 0: sprintf( text, STRING_OVERWORLD_DIALOG_SPELLS_OVERWORLD_CAST, STRING_SPELLMENU_MIDHEAL ); return;
             case 1: sprintf( text, STRING_OVERWORLD_DIALOG_HEAL_RESULT_1, dialog->insertionText ); return;
          }
-      case DialogMessageId_Spell_OverworldCastMidheal2:
+      case DialogId_Spell_OverworldCastMidheal2:
          switch ( dialog->section )
          {
             case 0: sprintf( text, STRING_OVERWORLD_DIALOG_SPELLS_OVERWORLD_CAST, STRING_SPELLMENU_MIDHEAL ); return;
             case 1: sprintf( text, STRING_OVERWORLD_DIALOG_HEAL_RESULT_2, dialog->insertionText ); return;
          }
-      case DialogMessageId_Spell_Blocked:
+      case DialogId_Spell_Blocked:
          switch ( dialog->section )
          {
             case 0: sprintf( text, STRING_OVERWORLD_DIALOG_SPELLS_OVERWORLD_CAST, dialog->insertionText ); return;

--- a/DragonQuestino/dialog.h
+++ b/DragonQuestino/dialog.h
@@ -1,5 +1,5 @@
-#if !defined( SCROLLING_DIALOG_H )
-#define SCROLLING_DIALOG_H
+#if !defined( DIALOG_H )
+#define DIALOG_H
 
 #include "common.h"
 #include "vector.h"
@@ -13,12 +13,12 @@
 typedef struct Screen_t Screen_t;
 typedef struct Player_t Player_t;
 
-typedef struct ScrollingDialog_t
+typedef struct Dialog_t
 {
    Screen_t* screen;
    Player_t* player;
 
-   DialogMessageId_t messageId;
+   DialogId_t id;
    Vector2u16_t position;  // in pixels
    Vector2u16_t size;      // in characters
    uint32_t lineWidth;     // in characters
@@ -37,23 +37,23 @@ typedef struct ScrollingDialog_t
    Bool_t showCarat;
    float blinkSeconds;
 }
-ScrollingDialog_t;
+Dialog_t;
 
 #if defined( __cplusplus )
 extern "C" {
 #endif
 
-void ScrollingDialog_Init( ScrollingDialog_t* dialog, Screen_t* screen, Player_t* player );
-void ScrollingDialog_Load( ScrollingDialog_t* dialog, DialogMessageId_t messageId );
-void ScrollingDialog_SetInsertionText( ScrollingDialog_t* dialog, const char* text );
-void ScrollingDialog_Draw( ScrollingDialog_t* dialog );
-Bool_t ScrollingDialog_Next( ScrollingDialog_t* dialog );
-void ScrollingDialog_Skip( ScrollingDialog_t* dialog );
-void ScrollingDialog_Tic( ScrollingDialog_t* dialog );
-Bool_t ScrollingDialog_IsDone( ScrollingDialog_t* dialog );
+void Dialog_Init( Dialog_t* dialog, Screen_t* screen, Player_t* player );
+void Dialog_Load( Dialog_t* dialog, DialogId_t id );
+void Dialog_SetInsertionText( Dialog_t* dialog, const char* text );
+void Dialog_Draw( Dialog_t* dialog );
+Bool_t Dialog_Next( Dialog_t* dialog );
+void Dialog_Skip( Dialog_t* dialog );
+void Dialog_Tic( Dialog_t* dialog );
+Bool_t Dialog_IsDone( Dialog_t* dialog );
 
 #if defined( __cplusplus )
 }
 #endif
 
-#endif // SCROLLING_DIALOG_H
+#endif // DIALOG_H

--- a/DragonQuestino/enums.h
+++ b/DragonQuestino/enums.h
@@ -27,35 +27,42 @@ typedef enum Direction_t
 }
 Direction_t;
 
-typedef enum GameState_t
+typedef enum MainState_t
 {
-   GameState_Overworld = 0,
-   GameState_Overworld_Waiting,
-   GameState_Overworld_MainMenu,
-   GameState_Overworld_SpellMenu,
-   GameState_Overworld_ItemMenu,
-   GameState_Overworld_ZoomMenu,
-   GameState_Overworld_ScrollingDialog,
+   MainState_Overworld = 0,
+   MainState_Battle,
 
-   GameState_Count
+   MainState_Count
 }
-GameState_t;
+MainState_t;
 
-typedef enum Animation_t
+typedef enum SubState_t
 {
-   Animation_Overworld_Pause = 0,
-   Animation_TileMap_FadeOut,
-   Animation_TileMap_FadePause,
-   Animation_TileMap_FadeIn,
-   Animation_TileMap_WhiteOut,
-   Animation_TileMap_WhitePause,
-   Animation_TileMap_WhiteIn,
-   Animation_RainbowBridge_Trippy,
-   Animation_RainbowBridge_WhiteOut,
-   Animation_RainbowBridge_FadeIn,
-   Animation_RainbowBridge_Pause,
+   SubState_None = 0,
+   SubState_Waiting,
+   SubState_Menu,
+   SubState_Animation,
+   SubState_Dialog,
 
-   Animation_Count
+   SubState_Count
+}
+SubState_t;
+
+typedef enum AnimationId_t
+{
+   AnimationId_Overworld_Pause = 0,
+   AnimationId_TileMap_FadeOut,
+   AnimationId_TileMap_FadePause,
+   AnimationId_TileMap_FadeIn,
+   AnimationId_TileMap_WhiteOut,
+   AnimationId_TileMap_WhitePause,
+   AnimationId_TileMap_WhiteIn,
+   AnimationId_RainbowBridge_Trippy,
+   AnimationId_RainbowBridge_WhiteOut,
+   AnimationId_RainbowBridge_FadeIn,
+   AnimationId_RainbowBridge_Pause,
+
+   AnimationId_Count
 }
 Animation_t;
 
@@ -94,12 +101,12 @@ MenuId_t;
 
 typedef enum MenuCommand_t
 {
-   MenuCommand_OverworldMain_Talk = 0,
-   MenuCommand_OverworldMain_Status,
-   MenuCommand_OverworldMain_Search,
-   MenuCommand_OverworldMain_Spell,
-   MenuCommand_OverworldMain_Item,
-   MenuCommand_OverworldMain_Door,
+   MenuCommand_Overworld_Talk = 0,
+   MenuCommand_Overworld_Status,
+   MenuCommand_Overworld_Search,
+   MenuCommand_Overworld_Spell,
+   MenuCommand_Overworld_Item,
+   MenuCommand_Overworld_Door,
 
    MenuCommand_Spell_Heal,
    MenuCommand_Spell_Sizz,
@@ -133,59 +140,59 @@ typedef enum MenuCommand_t
 }
 MenuCommand_t;
 
-typedef enum DialogMessageId_t
+typedef enum DialogId_t
 {
-   DialogMessageId_Talk_NobodyThere = 0,
-   DialogMessageId_Search_NothingFound,
-   DialogMessageId_Search_FoundItem,
-   DialogMessageId_Search_FoundHiddenStairs,
-   DialogMessageId_Spell_None,
-   DialogMessageId_Spell_OverworldCantCast,
-   DialogMessageId_Spell_OverworldCastHeal1,
-   DialogMessageId_Spell_OverworldCastHeal2,
-   DialogMessageId_Spell_OverworldCastMidheal1,
-   DialogMessageId_Spell_OverworldCastMidheal2,
-   DialogMessageId_Spell_OverworldCastGlowCursed,
-   DialogMessageId_Spell_OverworldCastGlow,
-   DialogMessageId_Spell_CastRepelCursed,
-   DialogMessageId_Spell_CastRepel,
-   DialogMessageId_Spell_CastEvacCursed,
-   DialogMessageId_Spell_CastEvac,
-   DialogMessageId_Spell_CastZoom,
-   DialogMessageId_Spell_NotEnoughMp,
-   DialogMessageId_Spell_Blocked,
-   DialogMessageId_Item_None,
-   DialogMessageId_Door_None,
-   DialogMessageId_Door_NoKeys,
+   DialogId_Talk_NobodyThere = 0,
+   DialogId_Search_NothingFound,
+   DialogId_Search_FoundItem,
+   DialogId_Search_FoundHiddenStairs,
+   DialogId_Spell_None,
+   DialogId_Spell_OverworldCantCast,
+   DialogId_Spell_OverworldCastHeal1,
+   DialogId_Spell_OverworldCastHeal2,
+   DialogId_Spell_OverworldCastMidheal1,
+   DialogId_Spell_OverworldCastMidheal2,
+   DialogId_Spell_OverworldCastGlowCursed,
+   DialogId_Spell_OverworldCastGlow,
+   DialogId_Spell_CastRepelCursed,
+   DialogId_Spell_CastRepel,
+   DialogId_Spell_CastEvacCursed,
+   DialogId_Spell_CastEvac,
+   DialogId_Spell_CastZoom,
+   DialogId_Spell_NotEnoughMp,
+   DialogId_Spell_Blocked,
+   DialogId_Item_None,
+   DialogId_Door_None,
+   DialogId_Door_NoKeys,
 
-   DialogMessageId_FullyHealed,
-   DialogMessageId_HolyProtection_Off,
+   DialogId_FullyHealed,
+   DialogId_HolyProtection_Off,
 
-   DialogMessageId_Use_Herb1,
-   DialogMessageId_Use_Herb2,
-   DialogMessageId_Use_WingCantUse,
-   DialogMessageId_Use_Wing,
-   DialogMessageId_Use_FairyWaterCursed,
-   DialogMessageId_Use_FairyWater,
-   DialogMessageId_Use_TorchCantUse,
-   DialogMessageId_Use_Torch,
-   DialogMessageId_Use_FairyFlute,
-   DialogMessageId_Use_SilverHarp,
-   DialogMessageId_Use_GwaelynsLoveCantUse,
-   DialogMessageId_Use_GwaelynsLove,
-   DialogMessageId_Use_RainbowDropCantUse,
-   DialogMessageId_Use_RainbowDrop,
-   DialogMessageId_Use_CursedBelt,
+   DialogId_Use_Herb1,
+   DialogId_Use_Herb2,
+   DialogId_Use_WingCantUse,
+   DialogId_Use_Wing,
+   DialogId_Use_FairyWaterCursed,
+   DialogId_Use_FairyWater,
+   DialogId_Use_TorchCantUse,
+   DialogId_Use_Torch,
+   DialogId_Use_FairyFlute,
+   DialogId_Use_SilverHarp,
+   DialogId_Use_GwaelynsLoveCantUse,
+   DialogId_Use_GwaelynsLove,
+   DialogId_Use_RainbowDropCantUse,
+   DialogId_Use_RainbowDrop,
+   DialogId_Use_CursedBelt,
 
-   DialogMessageId_Chest_ItemCollected,
-   DialogMessageId_Chest_ItemNoSpace,
-   DialogMessageId_Chest_GoldCollected,
-   DialogMessageId_Chest_GoldNoSpace,
-   DialogMessageId_Chest_Tablet,
-   DialogMessageId_Chest_DeathNecklace,
+   DialogId_Chest_ItemCollected,
+   DialogId_Chest_ItemNoSpace,
+   DialogId_Chest_GoldCollected,
+   DialogId_Chest_GoldNoSpace,
+   DialogId_Chest_Tablet,
+   DialogId_Chest_DeathNecklace,
 
-   DialogMessageId_Count
+   DialogId_Count
 }
-DialogMessageId_t;
+DialogId_t;
 
 #endif // ENUMS_H

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -122,6 +122,18 @@ void Game_ChangeSubState( Game_t* game, SubState_t newState )
    game->subState = newState;
 }
 
+void Game_FlagRedraw( Game_t* game )
+{
+   uint32_t i;
+
+   game->needsRedraw = True;
+
+   for ( i = 0; i < MenuId_Count; i++ )
+   {
+      game->menus[i].hasDrawn = False;
+   }
+}
+
 void Game_EnterTargetPortal( Game_t* game )
 {
    uint32_t destinationTileIndex = game->targetPortal->destinationTileIndex;

--- a/DragonQuestino/game.h
+++ b/DragonQuestino/game.h
@@ -62,6 +62,7 @@ void Game_Init( Game_t* game, uint16_t* screenBuffer );
 void Game_Tic( Game_t* game );
 void Game_ChangeMainState( Game_t* game, MainState_t newState );
 void Game_ChangeSubState( Game_t* game, SubState_t newState );
+void Game_FlagRedraw( Game_t* game );
 void Game_EnterTargetPortal( Game_t* game );
 void Game_OpenMenu( Game_t* game, MenuId_t id );
 void Game_OpenDialog( Game_t* game, DialogId_t id );
@@ -85,7 +86,7 @@ void Game_PlayerSteppedOnTile( Game_t* game, uint32_t tileIndex );
 void Game_Draw( Game_t* game );
 void Game_DrawOverworldQuickStatus( Game_t* game );
 void Game_DrawOverworldDeepStatus( Game_t* game );
-void Game_DrawNonUseableItems( Game_t* game, Bool_t hasUseableItems );
+void Game_DrawOverworldItemMenu( Game_t* game );
 
 // game_spells.c
 void Game_CastHeal( Game_t* game );

--- a/DragonQuestino/game.h
+++ b/DragonQuestino/game.h
@@ -9,7 +9,7 @@
 #include "input.h"
 #include "player.h"
 #include "menu.h"
-#include "scrolling_dialog.h"
+#include "dialog.h"
 
 #define OVERWORLD_INACTIVE_STATUS_SECONDS          1.0f
 
@@ -34,11 +34,15 @@ typedef struct Game_t
    TileMap_t tileMap;
    Clock_t clock;
    Input_t input;
-   GameState_t state;
+   MainState_t mainState;
+   SubState_t subState;
    Player_t player;
-   Menu_t menu;
-   ScrollingDialog_t scrollingDialog;
+   Menu_t menus[MenuId_Count];
+   Menu_t* activeMenu;
+   Dialog_t dialog;
    TilePortal_t zoomPortals[TILEMAP_TOWN_COUNT];
+
+   Bool_t needsRedraw;
 
    float overworldInactivitySeconds;
 
@@ -56,13 +60,14 @@ extern "C" {
 // game.c
 void Game_Init( Game_t* game, uint16_t* screenBuffer );
 void Game_Tic( Game_t* game );
-void Game_ChangeState( Game_t* game, GameState_t newState );
+void Game_ChangeMainState( Game_t* game, MainState_t newState );
+void Game_ChangeSubState( Game_t* game, SubState_t newState );
 void Game_EnterTargetPortal( Game_t* game );
 void Game_OpenMenu( Game_t* game, MenuId_t id );
-void Game_OpenScrollingDialog( Game_t* game, DialogMessageId_t messageId );
+void Game_OpenDialog( Game_t* game, DialogId_t id );
 void Game_Search( Game_t* game );
 void Game_OpenDoor( Game_t* game );
-void Game_ApplyHealing( Game_t* game, uint8_t minHp, uint8_t maxHp, DialogMessageId_t msg1, DialogMessageId_t msg2 );
+void Game_ApplyHealing( Game_t* game, uint8_t minHp, uint8_t maxHp, DialogId_t dialogId1, DialogId_t dialogId2 );
 
 // game_input.c
 void Game_HandleInput( Game_t* game );

--- a/DragonQuestino/game_animation.c
+++ b/DragonQuestino/game_animation.c
@@ -20,40 +20,40 @@ void Game_StartAnimation( Game_t* game, Animation_t animation )
 
    switch ( animation )
    {
-      case Animation_Overworld_Pause:
+      case AnimationId_Overworld_Pause:
          game->animationDuration = ANIMATION_OVERWORLD_PAUSE_DURATION;
          break;
-      case Animation_TileMap_FadeOut:
+      case AnimationId_TileMap_FadeOut:
          Screen_BackupPalette( &( game->screen ) );
          game->animationDuration = ANIMATION_TILEMAP_FADE_DURATION;
          break;
-      case Animation_TileMap_FadePause:
+      case AnimationId_TileMap_FadePause:
          game->animationDuration = ANIMATION_TILEMAP_FADEPAUSE_DURATION;
          break;
-      case Animation_TileMap_FadeIn:
+      case AnimationId_TileMap_FadeIn:
          game->animationDuration = ANIMATION_TILEMAP_FADE_DURATION;
          break;
-      case Animation_TileMap_WhiteOut:
+      case AnimationId_TileMap_WhiteOut:
          Screen_BackupPalette( &( game->screen ) );
          game->animationDuration = ANIMATION_TILEMAP_WHITE_DURATION;
          break;
-      case Animation_TileMap_WhitePause:
+      case AnimationId_TileMap_WhitePause:
          game->animationDuration = ANIMATION_TILEMAP_WHITEPAUSE_DURATION;
          break;
-      case Animation_TileMap_WhiteIn:
+      case AnimationId_TileMap_WhiteIn:
          game->animationDuration = ANIMATION_TILEMAP_WHITE_DURATION;
          break;
-      case Animation_RainbowBridge_Trippy:
+      case AnimationId_RainbowBridge_Trippy:
          Screen_BackupPalette( &( game->screen ) );
          game->animationDuration = ANIMATION_RAINBOWBRIDGE_TRIPPY_DURATION;
          break;
-      case Animation_RainbowBridge_WhiteOut:
+      case AnimationId_RainbowBridge_WhiteOut:
          game->animationDuration = ANIMATION_RAINBOWBRIDGE_WHITEOUT_DURATION;
          break;
-      case Animation_RainbowBridge_FadeIn:
+      case AnimationId_RainbowBridge_FadeIn:
          game->animationDuration = ANIMATION_RAINBOWBRIDGE_FADEIN_DURATION;
          break;
-      case Animation_RainbowBridge_Pause:
+      case AnimationId_RainbowBridge_Pause:
          game->animationDuration = ANIMATION_RAINBOWBRIDGE_PAUSE_DURATION;
          break;
    }
@@ -65,16 +65,16 @@ void Game_StopAnimation( Game_t* game )
 
    switch ( game->animation )
    {
-      case Animation_Overworld_Pause:
-         Game_ChangeState( game, GameState_Overworld );
+      case AnimationId_Overworld_Pause:
+         Game_ChangeMainState( game, MainState_Overworld );
          break;
-      case Animation_TileMap_FadeIn:
-      case Animation_TileMap_WhiteIn:
-      case Animation_RainbowBridge_FadeIn:
+      case AnimationId_TileMap_FadeIn:
+      case AnimationId_TileMap_WhiteIn:
+      case AnimationId_RainbowBridge_FadeIn:
          Screen_RestorePalette( &( game->screen ) );
          break;
-      case Animation_RainbowBridge_Pause:
-         Game_ChangeState( game, GameState_Overworld );
+      case AnimationId_RainbowBridge_Pause:
+         Game_ChangeMainState( game, MainState_Overworld );
          break;
    }
 }
@@ -83,17 +83,17 @@ void Game_TicAnimation( Game_t* game )
 {
    switch ( game->animation )
    {
-      case Animation_Overworld_Pause: Game_TicAnimation_Overworld_Pause( game ); break;
-      case Animation_TileMap_FadeOut: Game_TicAnimation_TileMap_FadeOut( game ); break;
-      case Animation_TileMap_FadePause: Game_TicAnimation_TileMap_FadePause( game ); break;
-      case Animation_TileMap_FadeIn: Game_TicAnimation_TileMap_FadeIn( game ); break;
-      case Animation_TileMap_WhiteOut: Game_TicAnimation_TileMap_WhiteOut( game ); break;
-      case Animation_TileMap_WhitePause: Game_TicAnimation_TileMap_WhitePause( game ); break;
-      case Animation_TileMap_WhiteIn: Game_TicAnimation_TileMap_WhiteIn( game ); break;
-      case Animation_RainbowBridge_Trippy: Game_TicAnimation_RainbowBridge_Trippy( game ); break;
-      case Animation_RainbowBridge_WhiteOut: Game_TicAnimation_RainbowBridge_WhiteOut( game ); break;
-      case Animation_RainbowBridge_FadeIn: Game_TicAnimation_RainbowBridge_FadeIn( game ); break;
-      case Animation_RainbowBridge_Pause: Game_TicAnimation_RainbowBridge_Pause( game ); break;
+      case AnimationId_Overworld_Pause: Game_TicAnimation_Overworld_Pause( game ); break;
+      case AnimationId_TileMap_FadeOut: Game_TicAnimation_TileMap_FadeOut( game ); break;
+      case AnimationId_TileMap_FadePause: Game_TicAnimation_TileMap_FadePause( game ); break;
+      case AnimationId_TileMap_FadeIn: Game_TicAnimation_TileMap_FadeIn( game ); break;
+      case AnimationId_TileMap_WhiteOut: Game_TicAnimation_TileMap_WhiteOut( game ); break;
+      case AnimationId_TileMap_WhitePause: Game_TicAnimation_TileMap_WhitePause( game ); break;
+      case AnimationId_TileMap_WhiteIn: Game_TicAnimation_TileMap_WhiteIn( game ); break;
+      case AnimationId_RainbowBridge_Trippy: Game_TicAnimation_RainbowBridge_Trippy( game ); break;
+      case AnimationId_RainbowBridge_WhiteOut: Game_TicAnimation_RainbowBridge_WhiteOut( game ); break;
+      case AnimationId_RainbowBridge_FadeIn: Game_TicAnimation_RainbowBridge_FadeIn( game ); break;
+      case AnimationId_RainbowBridge_Pause: Game_TicAnimation_RainbowBridge_Pause( game ); break;
    }
 }
 
@@ -105,17 +105,17 @@ internal void Game_TicAnimation_Overworld_Pause( Game_t* game )
    {
       Game_StopAnimation( game );
 
-      if ( game->scrollingDialog.messageId == DialogMessageId_Spell_CastEvac )
+      if ( game->dialog.id == DialogId_Spell_CastEvac )
       {
          game->targetPortal = &( game->tileMap.evacPortal );
-         Game_StartAnimation( game, Animation_TileMap_FadeOut );
+         Game_StartAnimation( game, AnimationId_TileMap_FadeOut );
       }
-      else if ( game->scrollingDialog.messageId == DialogMessageId_Use_Wing ||
-                game->scrollingDialog.messageId == DialogMessageId_Spell_CastZoom )
+      else if ( game->dialog.id == DialogId_Use_Wing ||
+                game->dialog.id == DialogId_Spell_CastZoom )
       {
-         Game_StartAnimation( game, Animation_TileMap_WhiteOut );
+         Game_StartAnimation( game, AnimationId_TileMap_WhiteOut );
       }
-      else if ( game->scrollingDialog.messageId == DialogMessageId_Search_FoundHiddenStairs &&
+      else if ( game->dialog.id == DialogId_Search_FoundHiddenStairs &&
                 game->tileMap.id == TILEMAP_CHARLOCK_ID &&
                 game->player.tileIndex == TILEMAP_HIDDENSTAIRS_INDEX )
       {
@@ -123,10 +123,10 @@ internal void Game_TicAnimation_Overworld_Pause( Game_t* game )
       }
       else
       {
-         Game_ChangeState( game, GameState_Overworld );
+         Game_ChangeMainState( game, MainState_Overworld );
       }
 
-      game->scrollingDialog.messageId = DialogMessageId_Count;
+      game->dialog.id = DialogId_Count;
    }
 }
 
@@ -142,7 +142,7 @@ internal void Game_TicAnimation_TileMap_FadeOut( Game_t* game )
    {
       Game_EnterTargetPortal( game );
       Game_StopAnimation( game );
-      Game_StartAnimation( game, Animation_TileMap_FadePause );
+      Game_StartAnimation( game, AnimationId_TileMap_FadePause );
    }
    else
    {
@@ -163,7 +163,7 @@ internal void Game_TicAnimation_TileMap_FadePause( Game_t* game )
 
    if ( game->animationSeconds > game->animationDuration )
    {
-      Game_StartAnimation( game, Animation_TileMap_FadeIn );
+      Game_StartAnimation( game, AnimationId_TileMap_FadeIn );
    }
 }
 
@@ -204,7 +204,7 @@ internal void Game_TicAnimation_TileMap_WhiteOut( Game_t* game )
    {
       Game_EnterTargetPortal( game );
       Game_StopAnimation( game );
-      Game_StartAnimation( game, Animation_TileMap_WhitePause );
+      Game_StartAnimation( game, AnimationId_TileMap_WhitePause );
    }
    else
    {
@@ -227,7 +227,7 @@ internal void Game_TicAnimation_TileMap_WhitePause( Game_t* game )
 
    if ( game->animationSeconds > game->animationDuration )
    {
-      Game_StartAnimation( game, Animation_TileMap_WhiteIn );
+      Game_StartAnimation( game, AnimationId_TileMap_WhiteIn );
    }
 }
 
@@ -278,7 +278,7 @@ internal void Game_TicAnimation_RainbowBridge_Trippy( Game_t* game )
       game->gameFlags.usedRainbowDrop = True;
       TILE_SET_TEXTUREINDEX( game->tileMap.tiles[TILEMAP_RAINBOWBRIDGE_INDEX], 13 );
       TILE_TOGGLE_PASSABLE( game->tileMap.tiles[TILEMAP_RAINBOWBRIDGE_INDEX] );
-      Game_StartAnimation( game, Animation_RainbowBridge_WhiteOut );
+      Game_StartAnimation( game, AnimationId_RainbowBridge_WhiteOut );
    }
    else
    {
@@ -300,7 +300,7 @@ internal void Game_TicAnimation_RainbowBridge_WhiteOut( Game_t* game )
 
    if ( game->animationSeconds > game->animationDuration )
    {
-      Game_StartAnimation( game, Animation_RainbowBridge_FadeIn );
+      Game_StartAnimation( game, AnimationId_RainbowBridge_FadeIn );
    }
 }
 
@@ -314,7 +314,7 @@ internal void Game_TicAnimation_RainbowBridge_FadeIn( Game_t* game )
 
    if ( game->animationSeconds > game->animationDuration )
    {
-      Game_StartAnimation( game, Animation_RainbowBridge_Pause );
+      Game_StartAnimation( game, AnimationId_RainbowBridge_Pause );
    }
    else
    {

--- a/DragonQuestino/game_input.c
+++ b/DragonQuestino/game_input.c
@@ -4,31 +4,35 @@
 
 internal void Game_HandleOverworldInput( Game_t* game );
 internal void Game_HandleOverworldWaitingInput( Game_t* game );
-internal void Game_HandleOverworldScrollingDialogInput( Game_t* game );
-internal void Game_HandleMenuInput( Game_t* game );
+internal void Game_HandleOverworldDialogInput( Game_t* game );
+internal void Game_HandleOverworldMenuInput( Game_t* game );
 internal void Game_OpenOverworldSpellMenu( Game_t* game );
 internal void Game_OpenOverworldItemMenu( Game_t* game );
 internal void Game_OpenZoomMenu( Game_t* game );
 
 void Game_HandleInput( Game_t* game )
 {
-   switch ( game->state )
+   if ( game->mainState == MainState_Overworld )
    {
-      case GameState_Overworld:
-         Game_HandleOverworldInput( game );
-         break;
-      case GameState_Overworld_Waiting:
-         Game_HandleOverworldWaitingInput( game );
-         break;
-      case GameState_Overworld_MainMenu:
-      case GameState_Overworld_SpellMenu:
-      case GameState_Overworld_ItemMenu:
-      case GameState_Overworld_ZoomMenu:
-         Game_HandleMenuInput( game );
-         break;
-      case GameState_Overworld_ScrollingDialog:
-         Game_HandleOverworldScrollingDialogInput( game );
-         break;
+      switch ( game->subState )
+      {
+         case SubState_None:
+            Game_HandleOverworldInput( game );
+            break;
+         case SubState_Waiting:
+            Game_HandleOverworldWaitingInput( game );
+            break;
+         case SubState_Menu:
+            Game_HandleOverworldMenuInput( game );
+            break;
+         case SubState_Dialog:
+            Game_HandleOverworldDialogInput( game );
+            break;
+      }
+   }
+   else
+   {
+      // TODO: battle stuff
    }
 }
 
@@ -122,55 +126,55 @@ internal void Game_HandleOverworldWaitingInput( Game_t* game )
 {
    if ( Input_AnyButtonPressed( &( game->input ) ) )
    {
-      Game_StartAnimation( game, Animation_Overworld_Pause );
+      Game_StartAnimation( game, AnimationId_Overworld_Pause );
    }
 }
 
-internal void Game_HandleOverworldScrollingDialogInput( Game_t* game )
+internal void Game_HandleOverworldDialogInput( Game_t* game )
 {
    uint32_t e;
 
-   if ( ScrollingDialog_IsDone( &( game->scrollingDialog ) ) )
+   if ( Dialog_IsDone( &( game->dialog ) ) )
    {
       if ( Input_AnyButtonPressed( &( game->input ) ) )
       {
-         if ( game->scrollingDialog.messageId == DialogMessageId_Use_RainbowDrop )
+         if ( game->dialog.id == DialogId_Use_RainbowDrop )
          {
-            Game_StartAnimation( game, Animation_RainbowBridge_Trippy );
+            Game_StartAnimation( game, AnimationId_RainbowBridge_Trippy );
          }
          else
          {
-            Game_StartAnimation( game, Animation_Overworld_Pause );
+            Game_StartAnimation( game, AnimationId_Overworld_Pause );
          }
       }
    }
    else if ( game->input.buttonStates[Button_A].pressed || game->input.buttonStates[Button_B].pressed )
    {
-      if ( ScrollingDialog_Next( &( game->scrollingDialog ) ) )
+      if ( Dialog_Next( &( game->dialog ) ) )
       {
-         switch ( game->scrollingDialog.section )
+         switch ( game->dialog.section )
          {
             case 1:
-               switch ( game->scrollingDialog.messageId )
+               switch ( game->dialog.id )
                {
-                  case DialogMessageId_Use_Herb1:
-                  case DialogMessageId_Use_Herb2:
-                  case DialogMessageId_Spell_OverworldCastHeal1:
-                  case DialogMessageId_Spell_OverworldCastHeal2:
-                  case DialogMessageId_Spell_OverworldCastMidheal1:
-                  case DialogMessageId_Spell_OverworldCastMidheal2:
+                  case DialogId_Use_Herb1:
+                  case DialogId_Use_Herb2:
+                  case DialogId_Spell_OverworldCastHeal1:
+                  case DialogId_Spell_OverworldCastHeal2:
+                  case DialogId_Spell_OverworldCastMidheal1:
+                  case DialogId_Spell_OverworldCastMidheal2:
                      Game_DrawOverworldQuickStatus( game );
                      break;
-                  case DialogMessageId_Use_CursedBelt:
-                  case DialogMessageId_Chest_DeathNecklace:
+                  case DialogId_Use_CursedBelt:
+                  case DialogId_Chest_DeathNecklace:
                      Player_SetCursed( &( game->player ), True );
                      TileMap_StartGlowTransition( &( game->tileMap ) );
                      break;
-                  case DialogMessageId_Use_GwaelynsLove:
+                  case DialogId_Use_GwaelynsLove:
                      e = Player_GetExperienceRemaining( &( game->player ) );
                      if ( e == 0 )
                      {
-                        ScrollingDialog_Skip( &( game->scrollingDialog ) );
+                        Dialog_Skip( &( game->dialog ) );
                      }
                      break;
                }
@@ -180,25 +184,25 @@ internal void Game_HandleOverworldScrollingDialogInput( Game_t* game )
    }
 }
 
-internal void Game_HandleMenuInput( Game_t* game )
+internal void Game_HandleOverworldMenuInput( Game_t* game )
 {
    uint32_t i;
 
    if ( game->input.buttonStates[Button_A].pressed )
    {
-      Menu_ResetCarat( &( game->menu ) );
+      Menu_ResetCarat( game->activeMenu );
 
-      switch ( game->menu.items[game->menu.selectedIndex].command )
+      switch ( game->activeMenu->items[game->activeMenu->selectedIndex].command )
       {
-         case MenuCommand_OverworldMain_Talk: Game_OpenScrollingDialog( game, DialogMessageId_Talk_NobodyThere ); break;
-         case MenuCommand_OverworldMain_Status:
+         case MenuCommand_Overworld_Talk: Game_OpenDialog( game, DialogId_Talk_NobodyThere ); break;
+         case MenuCommand_Overworld_Status:
             Game_DrawOverworldDeepStatus( game );
-            Game_ChangeState( game, GameState_Overworld_Waiting );
+            Game_ChangeSubState( game, SubState_Waiting );
             break;
-         case MenuCommand_OverworldMain_Search: Game_Search( game ); break;
-         case MenuCommand_OverworldMain_Spell: Game_OpenOverworldSpellMenu( game ); break;
-         case MenuCommand_OverworldMain_Item: Game_OpenOverworldItemMenu( game ); break;
-         case MenuCommand_OverworldMain_Door: Game_OpenDoor( game ); break;
+         case MenuCommand_Overworld_Search: Game_Search( game ); break;
+         case MenuCommand_Overworld_Spell: Game_OpenOverworldSpellMenu( game ); break;
+         case MenuCommand_Overworld_Item: Game_OpenOverworldItemMenu( game ); break;
+         case MenuCommand_Overworld_Door: Game_OpenDoor( game ); break;
 
          case MenuCommand_Spell_Heal: Game_CastHeal( game ); break;
          case MenuCommand_Spell_Glow: Game_CastGlow( game ); break;
@@ -227,24 +231,32 @@ internal void Game_HandleMenuInput( Game_t* game )
    }
    else if ( game->input.buttonStates[Button_B].pressed )
    {
-      // TODO: some of these should probably return to their parent menus
-      switch ( game->state )
+      if ( game->mainState == MainState_Overworld )
       {
-         case GameState_Overworld_MainMenu:
-         case GameState_Overworld_SpellMenu:
-         case GameState_Overworld_ItemMenu:
-         case GameState_Overworld_ZoomMenu:
-            Game_ChangeState( game, GameState_Overworld );
-            break;
+         switch ( game->activeMenu->id )
+         {
+            case MenuId_OverworldItem:
+            case MenuId_OverworldSpell:
+               Game_OpenMenu( game, MenuId_Overworld );
+               game->needsRedraw = True;
+               break;
+            default:
+               Game_ChangeMainState( game, MainState_Overworld );
+               break;
+         }
+      }
+      else
+      {
+         // TODO: battle stuff
       }
    }
-   else
+   else if ( game->activeMenu->itemCount )
    {
       for ( i = 0; i < Direction_Count; i++ )
       {
          if ( game->input.buttonStates[i].pressed )
          {
-            Menu_MoveSelection( &( game->menu ), (Direction_t)i );
+            Menu_MoveSelection( game->activeMenu, (Direction_t)i );
          }
       }
    }
@@ -254,7 +266,7 @@ internal void Game_OpenOverworldSpellMenu( Game_t* game )
 {
    if ( !game->player.spells )
    {
-      Game_OpenScrollingDialog( game, DialogMessageId_Spell_None );
+      Game_OpenDialog( game, DialogId_Spell_None );
    }
    else if ( SPELL_GET_MAPUSEABLECOUNT( game->player.spells, game->tileMap.isDungeon, game->tileMap.isDark ) )
    {
@@ -262,7 +274,7 @@ internal void Game_OpenOverworldSpellMenu( Game_t* game )
    }
    else
    {
-      Game_OpenScrollingDialog( game, DialogMessageId_Spell_OverworldCantCast );
+      Game_OpenDialog( game, DialogId_Spell_OverworldCantCast );
    }
 }
 
@@ -273,7 +285,7 @@ internal void Game_OpenOverworldItemMenu( Game_t* game )
 
    if ( useableCount == 0 && nonUseableCount == 0 )
    {
-      Game_OpenScrollingDialog( game, DialogMessageId_Item_None );
+      Game_OpenDialog( game, DialogId_Item_None );
    }
    else
    {
@@ -288,7 +300,7 @@ internal void Game_OpenOverworldItemMenu( Game_t* game )
       }
       else
       {
-         Game_ChangeState( game, GameState_Overworld_Waiting );
+         Game_ChangeSubState( game, SubState_Waiting );
       }
    }
 }
@@ -299,7 +311,7 @@ internal void Game_OpenZoomMenu( Game_t* game )
 
    if ( game->player.stats.magicPoints < SPELL_ZOOM_MP )
    {
-      Game_OpenScrollingDialog( game, DialogMessageId_Spell_NotEnoughMp );
+      Game_OpenDialog( game, DialogId_Spell_NotEnoughMp );
    }
    else if ( townCount > 0 )
    {

--- a/DragonQuestino/game_input.c
+++ b/DragonQuestino/game_input.c
@@ -169,6 +169,7 @@ internal void Game_HandleOverworldDialogInput( Game_t* game )
                   case DialogId_Chest_DeathNecklace:
                      Player_SetCursed( &( game->player ), True );
                      TileMap_StartGlowTransition( &( game->tileMap ) );
+                     Game_FlagRedraw( game );
                      break;
                   case DialogId_Use_GwaelynsLove:
                      e = Player_GetExperienceRemaining( &( game->player ) );
@@ -238,7 +239,7 @@ internal void Game_HandleOverworldMenuInput( Game_t* game )
             case MenuId_OverworldItem:
             case MenuId_OverworldSpell:
                Game_OpenMenu( game, MenuId_Overworld );
-               game->needsRedraw = True;
+               Game_FlagRedraw( game );
                break;
             default:
                Game_ChangeMainState( game, MainState_Overworld );
@@ -280,28 +281,14 @@ internal void Game_OpenOverworldSpellMenu( Game_t* game )
 
 internal void Game_OpenOverworldItemMenu( Game_t* game )
 {
-   uint32_t useableCount = ITEM_GET_MAPUSEABLECOUNT( game->player.items );
-   uint32_t nonUseableCount = ITEM_GET_MAPNONUSEABLECOUNT( game->player.items );
-
-   if ( useableCount == 0 && nonUseableCount == 0 )
+   if ( ITEM_GET_MAPUSEABLECOUNT( game->player.items ) == 0 && ITEM_GET_MAPNONUSEABLECOUNT( game->player.items ) == 0 )
    {
       Game_OpenDialog( game, DialogId_Item_None );
    }
    else
    {
-      if ( nonUseableCount > 0 )
-      {
-         Game_DrawNonUseableItems( game, ( useableCount > 0 ) ? True : False );
-      }
-
-      if ( useableCount > 0 )
-      {
-         Game_OpenMenu( game, MenuId_OverworldItem );
-      }
-      else
-      {
-         Game_ChangeSubState( game, SubState_Waiting );
-      }
+      Game_OpenMenu( game, MenuId_OverworldItem );
+      Game_DrawOverworldItemMenu( game );
    }
 }
 

--- a/DragonQuestino/game_items.c
+++ b/DragonQuestino/game_items.c
@@ -4,12 +4,12 @@ void Game_UseHerb( Game_t* game )
 {
    if ( game->player.stats.hitPoints == game->player.stats.maxHitPoints )
    {
-      Game_OpenScrollingDialog( game, DialogMessageId_FullyHealed );
+      Game_OpenDialog( game, DialogId_FullyHealed );
    }
    else
    {
       ITEM_SET_HERBCOUNT( game->player.items, ITEM_GET_HERBCOUNT( game->player.items ) - 1 );
-      Game_ApplyHealing( game, ITEM_HERB_MINEFFECT, ITEM_HERB_MAXEFFECT, DialogMessageId_Use_Herb1, DialogMessageId_Use_Herb2 );
+      Game_ApplyHealing( game, ITEM_HERB_MINEFFECT, ITEM_HERB_MAXEFFECT, DialogId_Use_Herb1, DialogId_Use_Herb2 );
    }
 }
 
@@ -17,13 +17,13 @@ void Game_UseWing( Game_t* game )
 {
    if ( game->tileMap.isDungeon )
    {
-      Game_OpenScrollingDialog( game, DialogMessageId_Use_WingCantUse );
+      Game_OpenDialog( game, DialogId_Use_WingCantUse );
    }
    else
    {
       ITEM_SET_WINGCOUNT( game->player.items, ITEM_GET_WINGCOUNT( game->player.items ) - 1 );
       game->targetPortal = &( game->zoomPortals[TILEMAP_TANTEGEL_TOWN_ID] );
-      Game_OpenScrollingDialog( game, DialogMessageId_Use_Wing );
+      Game_OpenDialog( game, DialogId_Use_Wing );
    }
 }
 
@@ -33,12 +33,12 @@ void Game_UseFairyWater( Game_t* game )
 
    if ( game->player.isCursed )
    {
-      Game_OpenScrollingDialog( game, DialogMessageId_Use_FairyWaterCursed );
+      Game_OpenDialog( game, DialogId_Use_FairyWaterCursed );
    }
    else
    {
       Player_SetHolyProtection( &( game->player ), True );
-      Game_OpenScrollingDialog( game, DialogMessageId_Use_FairyWater );
+      Game_OpenDialog( game, DialogId_Use_FairyWater );
    }
 }
 
@@ -54,22 +54,22 @@ void Game_UseTorch( Game_t* game )
       }
 
       ITEM_SET_TORCHCOUNT( game->player.items, ITEM_GET_TORCHCOUNT( game->player.items ) - 1 );
-      Game_OpenScrollingDialog( game, DialogMessageId_Use_Torch );
+      Game_OpenDialog( game, DialogId_Use_Torch );
    }
    else
    {
-      Game_OpenScrollingDialog( game, DialogMessageId_Use_TorchCantUse );
+      Game_OpenDialog( game, DialogId_Use_TorchCantUse );
    }
 }
 
 void Game_UseSilverHarp( Game_t* game )
 {
-   Game_OpenScrollingDialog( game, DialogMessageId_Use_SilverHarp );
+   Game_OpenDialog( game, DialogId_Use_SilverHarp );
 }
 
 void Game_UseFairyFlute( Game_t* game )
 {
-   Game_OpenScrollingDialog( game, DialogMessageId_Use_FairyFlute );
+   Game_OpenDialog( game, DialogId_Use_FairyFlute );
 }
 
 void Game_UseGwaelynsLove( Game_t* game )
@@ -101,12 +101,12 @@ void Game_UseGwaelynsLove( Game_t* game )
                   ( px > tx ) ? ( px - tx ) : ( tx - px ), ( px > tx ) ? STRING_WEST : STRING_EAST );
       }
 
-      ScrollingDialog_SetInsertionText( &( game->scrollingDialog ), msg );
-      Game_OpenScrollingDialog( game, DialogMessageId_Use_GwaelynsLove );
+      Dialog_SetInsertionText( &( game->dialog ), msg );
+      Game_OpenDialog( game, DialogId_Use_GwaelynsLove );
    }
    else
    {
-      Game_OpenScrollingDialog( game, DialogMessageId_Use_GwaelynsLoveCantUse );
+      Game_OpenDialog( game, DialogId_Use_GwaelynsLoveCantUse );
    }
 }
 
@@ -116,16 +116,16 @@ void Game_UseRainbowDrop( Game_t* game )
         game->player.tileIndex == ( TILEMAP_RAINBOWBRIDGE_INDEX + 1 ) &&
         game->player.sprite.direction == Direction_Left )
    {
-      Game_OpenScrollingDialog( game, DialogMessageId_Use_RainbowDrop );
+      Game_OpenDialog( game, DialogId_Use_RainbowDrop );
    }
    else
    {
-      Game_OpenScrollingDialog( game, DialogMessageId_Use_RainbowDropCantUse );
+      Game_OpenDialog( game, DialogId_Use_RainbowDropCantUse );
    }
 }
 
 void Game_UseCursedBelt( Game_t* game )
 {
    ITEM_TOGGLE_HASCURSEDBELT( game->player.items );
-   Game_OpenScrollingDialog( game, DialogMessageId_Use_CursedBelt );
+   Game_OpenDialog( game, DialogId_Use_CursedBelt );
 }

--- a/DragonQuestino/game_physics.c
+++ b/DragonQuestino/game_physics.c
@@ -149,7 +149,7 @@ void Game_PlayerSteppedOnTile( Game_t* game, uint32_t tileIndex )
    if ( portal )
    {
       game->targetPortal = portal;
-      Game_StartAnimation( game, Animation_TileMap_FadeOut );
+      Game_StartAnimation( game, AnimationId_TileMap_FadeOut );
       return;
    }
 
@@ -171,7 +171,7 @@ void Game_PlayerSteppedOnTile( Game_t* game, uint32_t tileIndex )
       if ( game->player.holyProtectionSteps >= HOLY_PROTECTION_MAX_STEPS )
       {
          game->player.hasHolyProtection = False;
-         Game_OpenScrollingDialog( game, DialogMessageId_HolyProtection_Off );
+         Game_OpenDialog( game, DialogId_HolyProtection_Off );
       }
    }
 }

--- a/DragonQuestino/game_render.c
+++ b/DragonQuestino/game_render.c
@@ -10,37 +10,55 @@ void Game_Draw( Game_t* game )
    {
       switch ( game->animation )
       {
-         case Animation_Overworld_Pause:
-         case Animation_TileMap_FadeOut:
-         case Animation_TileMap_FadePause:
-         case Animation_TileMap_FadeIn:
-         case Animation_TileMap_WhiteOut:
-         case Animation_TileMap_WhitePause:
-         case Animation_TileMap_WhiteIn:
-         case Animation_RainbowBridge_Trippy:
-         case Animation_RainbowBridge_WhiteOut:
-         case Animation_RainbowBridge_FadeIn:
-         case Animation_RainbowBridge_Pause:
+         default:
             Game_DrawOverworld( game );
             break;
       }
    }
    else
    {
-      switch ( game->state )
+      if ( game->mainState == MainState_Overworld )
       {
-         case GameState_Overworld:
+         if ( game->needsRedraw )
+         {
             Game_DrawOverworld( game );
-            break;
-         case GameState_Overworld_MainMenu:
-         case GameState_Overworld_SpellMenu:
-         case GameState_Overworld_ItemMenu:
-         case GameState_Overworld_ZoomMenu:
-            Menu_Draw( &( game->menu ) );
-            break;
-         case GameState_Overworld_ScrollingDialog:
-            ScrollingDialog_Draw( &( game->scrollingDialog ) );
-            break;
+            game->needsRedraw = False;
+
+            switch ( game->subState )
+            {
+               case SubState_Menu:
+                  Game_DrawOverworldQuickStatus( game );
+                  Menu_Draw( &( game->menus[MenuId_Overworld] ) );
+                  switch ( game->activeMenu->id )
+                  {
+                     case MenuId_OverworldItem:
+                        Menu_Draw( &( game->menus[MenuId_OverworldItem] ) );
+                        break;
+                     case MenuId_OverworldSpell:
+                        Menu_Draw( &( game->menus[MenuId_OverworldSpell] ) );
+                        break;
+                  }
+            }
+         }
+         else
+         {
+            switch ( game->subState )
+            {
+               case SubState_None:
+                  Game_DrawOverworld( game );
+                  break;
+               case SubState_Menu:
+                  Menu_Draw( game->activeMenu );
+                  break;
+               case SubState_Dialog:
+                  Dialog_Draw( &( game->dialog ) );
+                  break;
+            }
+         }
+      }
+      else
+      {
+         // TODO: battle stuff
       }
    }
 }
@@ -177,7 +195,7 @@ internal void Game_DrawOverworld( Game_t* game )
    TileMap_Draw( &( game->tileMap ) );
    Game_DrawPlayer( game );
 
-   if ( game->state == GameState_Overworld && game->overworldInactivitySeconds > OVERWORLD_INACTIVE_STATUS_SECONDS )
+   if ( game->subState == SubState_None && game->overworldInactivitySeconds > OVERWORLD_INACTIVE_STATUS_SECONDS )
    {
       Game_DrawOverworldQuickStatus( game );
    }

--- a/DragonQuestino/game_spells.c
+++ b/DragonQuestino/game_spells.c
@@ -13,7 +13,7 @@ void Game_CastHeal( Game_t* game )
 
    if ( game->player.stats.hitPoints == UINT8_MAX )
    {
-      Game_OpenScrollingDialog( game, DialogMessageId_FullyHealed );
+      Game_OpenDialog( game, DialogId_FullyHealed );
    }
    else
    {
@@ -21,7 +21,7 @@ void Game_CastHeal( Game_t* game )
       game->player.stats.magicPoints -= SPELL_HEAL_MP;
       Game_DrawOverworldQuickStatus( game );
       Game_ApplyHealing( game, SPELL_HEAL_MINEFFECT, maxEffect,
-                         DialogMessageId_Spell_OverworldCastHeal1, DialogMessageId_Spell_OverworldCastHeal2 );
+                         DialogId_Spell_OverworldCastHeal1, DialogId_Spell_OverworldCastHeal2 );
    }
 }
 
@@ -37,7 +37,7 @@ void Game_CastGlow( Game_t* game )
       if ( game->player.isCursed )
       {
          TileMap_SetTargetGlowDiameter( &( game->tileMap ), 1 );
-         Game_OpenScrollingDialog( game, DialogMessageId_Spell_OverworldCastGlowCursed );
+         Game_OpenDialog( game, DialogId_Spell_OverworldCastGlowCursed );
       }
       else
       {
@@ -48,7 +48,7 @@ void Game_CastGlow( Game_t* game )
             TileMap_StartGlowTransition( &( game->tileMap ) );
          }
 
-         Game_OpenScrollingDialog( game, DialogMessageId_Spell_OverworldCastGlow );
+         Game_OpenDialog( game, DialogId_Spell_OverworldCastGlow );
       }
    }
 }
@@ -64,11 +64,11 @@ void Game_CastEvac( Game_t* game )
 
       if ( game->player.isCursed )
       {
-         Game_OpenScrollingDialog( game, DialogMessageId_Spell_CastEvacCursed );
+         Game_OpenDialog( game, DialogId_Spell_CastEvacCursed );
       }
       else
       {
-         Game_OpenScrollingDialog( game, DialogMessageId_Spell_CastEvac );
+         Game_OpenDialog( game, DialogId_Spell_CastEvac );
       }
    }
 }
@@ -80,7 +80,7 @@ void Game_CastZoom( Game_t* game, uint32_t townId )
    game->player.stats.magicPoints -= SPELL_ZOOM_MP;
    game->targetPortal = &( game->zoomPortals[townId] );
    Game_DrawOverworldQuickStatus( game );
-   Game_OpenScrollingDialog( game, DialogMessageId_Spell_CastZoom );
+   Game_OpenDialog( game, DialogId_Spell_CastZoom );
 }
 
 void Game_CastRepel( Game_t* game )
@@ -92,12 +92,12 @@ void Game_CastRepel( Game_t* game )
 
    if ( game->player.isCursed )
    {
-      Game_OpenScrollingDialog( game, DialogMessageId_Spell_CastRepelCursed );
+      Game_OpenDialog( game, DialogId_Spell_CastRepelCursed );
    }
    else
    {
       Player_SetHolyProtection( &( game->player ), True );
-      Game_OpenScrollingDialog( game, DialogMessageId_Spell_CastRepel );
+      Game_OpenDialog( game, DialogId_Spell_CastRepel );
    }
 }
 
@@ -109,7 +109,7 @@ void Game_CastMidheal( Game_t* game )
 
    if ( game->player.stats.hitPoints == UINT8_MAX )
    {
-      Game_OpenScrollingDialog( game, DialogMessageId_FullyHealed );
+      Game_OpenDialog( game, DialogId_FullyHealed );
    }
    else
    {
@@ -117,7 +117,7 @@ void Game_CastMidheal( Game_t* game )
       game->player.stats.magicPoints -= SPELL_MIDHEAL_MP;
       Game_DrawOverworldQuickStatus( game );
       Game_ApplyHealing( game, SPELL_MIDHEAL_MINEFFECT, maxEffect,
-                         DialogMessageId_Spell_OverworldCastMidheal1, DialogMessageId_Spell_OverworldCastMidheal2 );
+                         DialogId_Spell_OverworldCastMidheal1, DialogId_Spell_OverworldCastMidheal2 );
    }
 }
 
@@ -125,15 +125,15 @@ internal Bool_t Game_CanCastSpell( Game_t* game, uint8_t requiredMp, const char*
 {
    if ( game->player.stats.magicPoints < requiredMp )
    {
-      Game_OpenScrollingDialog( game, DialogMessageId_Spell_NotEnoughMp );
+      Game_OpenDialog( game, DialogId_Spell_NotEnoughMp );
       return False;
    }
    else if ( game->tileMap.blocksMagic )
    {
       game->player.stats.magicPoints -= requiredMp;
       Game_DrawOverworldQuickStatus( game );
-      ScrollingDialog_SetInsertionText( &( game->scrollingDialog ), spellName );
-      Game_OpenScrollingDialog( game, DialogMessageId_Spell_Blocked );
+      Dialog_SetInsertionText( &( game->dialog ), spellName );
+      Game_OpenDialog( game, DialogId_Spell_Blocked );
       return False;
    }
 

--- a/DragonQuestino/menu.c
+++ b/DragonQuestino/menu.c
@@ -5,29 +5,35 @@
 #include "tile_map.h"
 
 internal void Menu_DrawCarat( Menu_t* menu );
-internal void Menu_LoadOverworld( Menu_t* menu );
-internal void Menu_LoadOverworldSpell( Menu_t* menu );
-internal void Menu_LoadOverworldItem( Menu_t* menu );
-internal void Menu_LoadZoom( Menu_t* menu );
+internal void Menu_InitOverworld( Menu_t* menu );
+internal void Menu_Update( Menu_t* menu );
+internal void Menu_UpdateOverworldSpell( Menu_t* menu );
+internal void Menu_UpdateOverworldItem( Menu_t* menu );
+internal void Menu_UpdateZoom( Menu_t* menu );
 
-void Menu_Init( Menu_t* menu, Screen_t* screen, Player_t* player, TileMap_t* tileMap )
+void Menu_Init( Menu_t* menu, MenuId_t id, Screen_t* screen, Player_t* player, TileMap_t* tileMap )
 {
    menu->screen = screen;
    menu->player = player;
    menu->tileMap = tileMap;
-}
+   menu->id = id;
 
-void Menu_Load( Menu_t* menu, MenuId_t id )
-{
    switch ( id )
    {
-      case MenuId_Overworld: Menu_LoadOverworld( menu ); break;
-      case MenuId_OverworldSpell: Menu_LoadOverworldSpell( menu ); break;
-      case MenuId_OverworldItem: Menu_LoadOverworldItem( menu ); break;
-      case MenuId_Zoom: Menu_LoadZoom( menu ); break;
+      case MenuId_Overworld:
+         Menu_InitOverworld( menu );
+         break;
+      default:
+         Menu_Update( menu );
+         break;
    }
+}
 
+void Menu_Reset( Menu_t* menu )
+{
    menu->hasDrawn = False;
+   menu->selectedIndex = 0;
+   Menu_Update( menu );
    Menu_ResetCarat( menu );
 }
 
@@ -136,6 +142,16 @@ void Menu_Tic( Menu_t* menu )
    }
 }
 
+internal void Menu_Update( Menu_t* menu )
+{
+   switch ( menu->id )
+   {
+      case MenuId_OverworldSpell: Menu_UpdateOverworldSpell( menu ); break;
+      case MenuId_OverworldItem: Menu_UpdateOverworldItem( menu ); break;
+      case MenuId_Zoom: Menu_UpdateZoom( menu ); break;
+   }
+}
+
 internal void Menu_DrawCarat( Menu_t* menu )
 {
    uint32_t i;
@@ -159,7 +175,7 @@ internal void Menu_DrawCarat( Menu_t* menu )
    }
 }
 
-internal void Menu_LoadOverworld( Menu_t* menu )
+internal void Menu_InitOverworld( Menu_t* menu )
 {
    uint32_t i;
 
@@ -170,12 +186,12 @@ internal void Menu_LoadOverworld( Menu_t* menu )
    strcpy( menu->items[3].text, STRING_OVERWORLD_MENU_SPELL );
    strcpy( menu->items[4].text, STRING_OVERWORLD_MENU_ITEM );
    strcpy( menu->items[5].text, STRING_OVERWORLD_MENU_DOOR );
-   menu->items[0].command = MenuCommand_OverworldMain_Talk;
-   menu->items[1].command = MenuCommand_OverworldMain_Status;
-   menu->items[2].command = MenuCommand_OverworldMain_Search;
-   menu->items[3].command = MenuCommand_OverworldMain_Spell;
-   menu->items[4].command = MenuCommand_OverworldMain_Item;
-   menu->items[5].command = MenuCommand_OverworldMain_Door;
+   menu->items[0].command = MenuCommand_Overworld_Talk;
+   menu->items[1].command = MenuCommand_Overworld_Status;
+   menu->items[2].command = MenuCommand_Overworld_Search;
+   menu->items[3].command = MenuCommand_Overworld_Spell;
+   menu->items[4].command = MenuCommand_Overworld_Item;
+   menu->items[5].command = MenuCommand_Overworld_Door;
    menu->itemCount = 6;
    for ( i = 0; i < menu->itemCount; i++ ) menu->items[i].twoLineText = False;
    menu->itemsPerColumn = 3;
@@ -192,7 +208,7 @@ internal void Menu_LoadOverworld( Menu_t* menu )
    menu->caratOffset = 1;
 }
 
-internal void Menu_LoadOverworldSpell( Menu_t* menu )
+internal void Menu_UpdateOverworldSpell( Menu_t* menu )
 {
    uint32_t i;
    uint32_t spells = menu->player->spells;
@@ -256,7 +272,7 @@ internal void Menu_LoadOverworldSpell( Menu_t* menu )
    }
 }
 
-internal void Menu_LoadOverworldItem( Menu_t* menu )
+internal void Menu_UpdateOverworldItem( Menu_t* menu )
 {
    uint32_t i = 0;
    uint32_t items = menu->player->items;
@@ -346,7 +362,7 @@ internal void Menu_LoadOverworldItem( Menu_t* menu )
    }
 }
 
-internal void Menu_LoadZoom( Menu_t* menu )
+internal void Menu_UpdateZoom( Menu_t* menu )
 {
    uint32_t i = 0;
    uint8_t tv = menu->player->townsVisited;

--- a/DragonQuestino/menu.h
+++ b/DragonQuestino/menu.h
@@ -26,6 +26,7 @@ typedef struct Menu_t
    Player_t* player;
    TileMap_t* tileMap;
 
+   MenuId_t id;
    char title[MENU_LINE_LENGTH];
    MenuItem_t items[MENU_MAX_ITEMS];
    uint32_t itemCount;
@@ -49,8 +50,8 @@ Menu_t;
 extern "C" {
 #endif
 
-void Menu_Init( Menu_t* menu, Screen_t* screen, Player_t* player, TileMap_t* tileMap );
-void Menu_Load( Menu_t* menu, MenuId_t id );
+void Menu_Init( Menu_t* menu, MenuId_t id, Screen_t* screen, Player_t* player, TileMap_t* tileMap );
+void Menu_Reset( Menu_t* menu );
 void Menu_Draw( Menu_t* menu );
 void Menu_ResetCarat( Menu_t* menu );
 void Menu_MoveSelection( Menu_t* menu, Direction_t direction );

--- a/DragonQuestino/player.c
+++ b/DragonQuestino/player.c
@@ -40,9 +40,12 @@ void Player_Init( Player_t* player, Screen_t* screen, TileMap_t* tileMap )
    player->items = 0;
    player->spells = 0;
 
-   // uncomment for testing
-   //player->spells = 0x3FF;
-   //SPELL_SET_HASSIZZ( player->spells );
+   // TODO: use this to test setting red text when health is low
+   //player->stats.hitPoints = 1;
+   //player->stats.magicPoints = 200;
+   //player->stats.maxHitPoints = 255;
+   //player->stats.maxMagicPoints = 255;
+   //SPELL_SET_HASHEAL( player->spells );
 }
 
 uint16_t Player_GetLevel( Player_t* player )

--- a/DragonQuestinoWinDev/DragonQuestinoWinDev/DragonQuestinoWinDev.vcxproj
+++ b/DragonQuestinoWinDev/DragonQuestinoWinDev/DragonQuestinoWinDev.vcxproj
@@ -32,7 +32,7 @@
     <ClInclude Include="..\..\DragonQuestino\player.h" />
     <ClInclude Include="..\..\DragonQuestino\random.h" />
     <ClInclude Include="..\..\DragonQuestino\screen.h" />
-    <ClInclude Include="..\..\DragonQuestino\scrolling_dialog.h" />
+    <ClInclude Include="..\..\DragonQuestino\dialog.h" />
     <ClInclude Include="..\..\DragonQuestino\sprite.h" />
     <ClInclude Include="..\..\DragonQuestino\strings.h" />
     <ClInclude Include="..\..\DragonQuestino\tables.h" />
@@ -56,7 +56,7 @@
     <ClCompile Include="..\..\DragonQuestino\player.c" />
     <ClCompile Include="..\..\DragonQuestino\random.c" />
     <ClCompile Include="..\..\DragonQuestino\screen.c" />
-    <ClCompile Include="..\..\DragonQuestino\scrolling_dialog.c" />
+    <ClCompile Include="..\..\DragonQuestino\dialog.c" />
     <ClCompile Include="..\..\DragonQuestino\sprite.c" />
     <ClCompile Include="..\..\DragonQuestino\tile_map.c" />
     <ClCompile Include="win_clock.c" />

--- a/DragonQuestinoWinDev/DragonQuestinoWinDev/DragonQuestinoWinDev.vcxproj.filters
+++ b/DragonQuestinoWinDev/DragonQuestinoWinDev/DragonQuestinoWinDev.vcxproj.filters
@@ -60,7 +60,7 @@
     <ClInclude Include="..\..\DragonQuestino\strings.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\DragonQuestino\scrolling_dialog.h">
+    <ClInclude Include="..\..\DragonQuestino\dialog.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\DragonQuestino\battle_stats.h">
@@ -122,7 +122,7 @@
     <ClCompile Include="..\..\DragonQuestino\menu.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\DragonQuestino\scrolling_dialog.c">
+    <ClCompile Include="..\..\DragonQuestino\dialog.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\DragonQuestino\game_input.c">

--- a/DragonQuestinoWinDev/DragonQuestinoWinDev/win_main.c
+++ b/DragonQuestinoWinDev/DragonQuestinoWinDev/win_main.c
@@ -231,6 +231,7 @@ internal void HandleKeyboardInput( uint32_t keyCode, LPARAM flags )
                break;
             case VK_TOGGLECURSED:
                Player_SetCursed( &( g_globals.game.player ), g_globals.game.player.isCursed ? False : True );
+               Game_FlagRedraw( &( g_globals.game ) );
                break;
          }
       }
@@ -455,7 +456,7 @@ internal void GetAllItems()
       ITEM_TOGGLE_HASCURSEDBELT( g_globals.game.player.items );
    }
 
-   g_globals.game.needsRedraw = True;
+   Game_FlagRedraw( &( g_globals.game ) );
 }
 
 internal void MaxOutStats()
@@ -482,5 +483,5 @@ internal void MaxOutStats()
       Menu_Reset( &( g_globals.game.menus[i] ) );
    }
 
-   g_globals.game.needsRedraw = True;
+   Game_FlagRedraw( &( g_globals.game ) );
 }

--- a/DragonQuestinoWinDev/DragonQuestinoWinDev/win_main.c
+++ b/DragonQuestinoWinDev/DragonQuestinoWinDev/win_main.c
@@ -454,10 +454,14 @@ internal void GetAllItems()
    {
       ITEM_TOGGLE_HASCURSEDBELT( g_globals.game.player.items );
    }
+
+   g_globals.game.needsRedraw = True;
 }
 
 internal void MaxOutStats()
 {
+   uint32_t i;
+
    g_globals.game.player.experience = UINT16_MAX;
    g_globals.game.player.gold = UINT16_MAX;
 
@@ -472,4 +476,11 @@ internal void MaxOutStats()
 
    g_globals.game.player.spells = 0x3FF;
    g_globals.game.player.townsVisited = 0x3F;
+
+   for ( i = 0; i < MenuId_Count; i++ )
+   {
+      Menu_Reset( &( g_globals.game.menus[i] ) );
+   }
+
+   g_globals.game.needsRedraw = True;
 }


### PR DESCRIPTION
## Overview

I reached a point where it was getting difficult to keep track of the game state, and realized if I wanted to do something like change the text color to red when the player is injured badly, I would need to be able to re-draw everything, which was complicated. This should simplify things somewhat, it introduces the idea of a "main state" (overworld or battle) and a "sub state" (none, waiting, menu, animation, dialog). Also, instead of having just one menu object that changes when you load a menu, I'm storing every menu in an array, which makes it MUCH easier to re-draw menus when necessary.

It's a little weird having a special case for the overworld items menu, but I'm cool with it for now, I think it'll be the only special-case menu.