### PR TITLE
Change text color to red when injured badly

### DIFF
--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -47,7 +47,6 @@ void Game_Init( Game_t* game, uint16_t* screenBuffer )
    game->mainState = MainState_Overworld;
    game->subState = SubState_None;
    game->targetPortal = 0;
-   game->needsRedraw = False;
    game->overworldInactivitySeconds = 0.0f;
 }
 
@@ -120,18 +119,6 @@ void Game_ChangeMainState( Game_t* game, MainState_t newState )
 void Game_ChangeSubState( Game_t* game, SubState_t newState )
 {
    game->subState = newState;
-}
-
-void Game_FlagRedraw( Game_t* game )
-{
-   uint32_t i;
-
-   game->needsRedraw = True;
-
-   for ( i = 0; i < MenuId_Count; i++ )
-   {
-      game->menus[i].hasDrawn = False;
-   }
 }
 
 void Game_EnterTargetPortal( Game_t* game )

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -1,5 +1,6 @@
 #include "game.h"
 #include "random.h"
+#include "math.h"
 
 internal void Game_TicOverworld( Game_t* game );
 internal void Game_CollectTreasure( Game_t* game, uint32_t treasureFlag );
@@ -235,13 +236,18 @@ void Game_OpenDoor( Game_t* game )
 
 void Game_ApplyHealing( Game_t* game, uint8_t minHp, uint8_t maxHp, DialogId_t dialogId1, DialogId_t dialogId2 )
 {
-   uint8_t amount;
    char str[16];
 
-   amount = Player_RestoreHitPoints( &( game->player ), Random_u8( minHp, maxHp ) );
-   sprintf( str, "%u", amount );
+   game->pendingPayload8u = Random_u8( minHp, maxHp );
+
+   if ( ( UINT8_MAX - game->player.stats.hitPoints ) < game->pendingPayload8u )
+   {
+      game->pendingPayload8u = UINT8_MAX - game->player.stats.hitPoints;
+   }
+
+   sprintf( str, "%u", game->pendingPayload8u );
    Dialog_SetInsertionText( &( game->dialog ), str );
-   Game_OpenDialog( game, ( amount == 1 ) ? dialogId1 : dialogId2 );
+   Game_OpenDialog( game, ( game->pendingPayload8u == 1 ) ? dialogId1 : dialogId2 );
 }
 
 internal void Game_TicOverworld( Game_t* game )

--- a/DragonQuestino/game.h
+++ b/DragonQuestino/game.h
@@ -42,8 +42,6 @@ typedef struct Game_t
    Dialog_t dialog;
    TilePortal_t zoomPortals[TILEMAP_TOWN_COUNT];
 
-   Bool_t needsRedraw;
-
    float overworldInactivitySeconds;
 
    Bool_t isAnimating;
@@ -62,7 +60,6 @@ void Game_Init( Game_t* game, uint16_t* screenBuffer );
 void Game_Tic( Game_t* game );
 void Game_ChangeMainState( Game_t* game, MainState_t newState );
 void Game_ChangeSubState( Game_t* game, SubState_t newState );
-void Game_FlagRedraw( Game_t* game );
 void Game_EnterTargetPortal( Game_t* game );
 void Game_OpenMenu( Game_t* game, MenuId_t id );
 void Game_OpenDialog( Game_t* game, DialogId_t id );

--- a/DragonQuestino/game.h
+++ b/DragonQuestino/game.h
@@ -44,6 +44,8 @@ typedef struct Game_t
 
    float overworldInactivitySeconds;
 
+   uint8_t pendingPayload8u;
+
    Bool_t isAnimating;
    Animation_t animation;
    float animationSeconds;

--- a/DragonQuestino/game_input.c
+++ b/DragonQuestino/game_input.c
@@ -163,6 +163,7 @@ internal void Game_HandleOverworldDialogInput( Game_t* game )
                   case DialogId_Spell_OverworldCastHeal2:
                   case DialogId_Spell_OverworldCastMidheal1:
                   case DialogId_Spell_OverworldCastMidheal2:
+                     Player_RestoreHitPoints( &( game->player ), game->pendingPayload8u );
                      Game_DrawOverworldQuickStatus( game );
                      break;
                   case DialogId_Use_CursedBelt:

--- a/DragonQuestino/game_input.c
+++ b/DragonQuestino/game_input.c
@@ -169,7 +169,7 @@ internal void Game_HandleOverworldDialogInput( Game_t* game )
                   case DialogId_Chest_DeathNecklace:
                      Player_SetCursed( &( game->player ), True );
                      TileMap_StartGlowTransition( &( game->tileMap ) );
-                     Game_FlagRedraw( game );
+                     game->screen.needsRedraw = True;
                      break;
                   case DialogId_Use_GwaelynsLove:
                      e = Player_GetExperienceRemaining( &( game->player ) );
@@ -239,7 +239,7 @@ internal void Game_HandleOverworldMenuInput( Game_t* game )
             case MenuId_OverworldItem:
             case MenuId_OverworldSpell:
                Game_OpenMenu( game, MenuId_Overworld );
-               Game_FlagRedraw( game );
+               game->screen.needsRedraw = True;
                break;
             default:
                Game_ChangeMainState( game, MainState_Overworld );

--- a/DragonQuestino/game_render.c
+++ b/DragonQuestino/game_render.c
@@ -7,6 +7,8 @@ internal void Game_DrawNonUseableItems( Game_t* game, Bool_t hasUseableItems );
 
 void Game_Draw( Game_t* game )
 {
+   uint32_t i;
+
    if ( game->isAnimating )
    {
       switch ( game->animation )
@@ -20,10 +22,16 @@ void Game_Draw( Game_t* game )
    {
       if ( game->mainState == MainState_Overworld )
       {
-         if ( game->needsRedraw )
+         if ( game->screen.needsRedraw )
          {
+            game->screen.needsRedraw = False;
+
+            for ( i = 0; i < MenuId_Count; i++ )
+            {
+               game->menus[i].hasDrawn = False;
+            }
+
             Game_DrawOverworld( game );
-            game->needsRedraw = False;
 
             switch ( game->subState )
             {

--- a/DragonQuestino/game_render.c
+++ b/DragonQuestino/game_render.c
@@ -57,6 +57,10 @@ void Game_Draw( Game_t* game )
                      case MenuId_OverworldItem:
                         Menu_Draw( &( game->menus[MenuId_Overworld] ) );
                         Game_DrawOverworldItemMenu( game );
+                        if ( game->dialog.id == DialogId_Use_Herb2 )
+                        {
+                           Game_DrawOverworldQuickStatus( game );
+                        }
                         break;
                      case MenuId_OverworldSpell:
                         Menu_Draw( &( game->menus[MenuId_Overworld] ) );

--- a/DragonQuestino/game_spells.c
+++ b/DragonQuestino/game_spells.c
@@ -19,9 +19,9 @@ void Game_CastHeal( Game_t* game )
    {
       maxEffect = game->player.isCursed ? ( SPELL_HEAL_MAXEFFECT / 2 ) : SPELL_HEAL_MAXEFFECT;
       game->player.stats.magicPoints -= SPELL_HEAL_MP;
-      Game_DrawOverworldQuickStatus( game );
       Game_ApplyHealing( game, SPELL_HEAL_MINEFFECT, maxEffect,
                          DialogId_Spell_OverworldCastHeal1, DialogId_Spell_OverworldCastHeal2 );
+      Game_DrawOverworldQuickStatus( game );
    }
 }
 

--- a/DragonQuestino/player.c
+++ b/DragonQuestino/player.c
@@ -42,12 +42,6 @@ void Player_Init( Player_t* player, Screen_t* screen, TileMap_t* tileMap )
    player->items = 0;
    player->spells = 0;
 
-   player->stats.hitPoints = 1;
-   player->stats.magicPoints = 200;
-   player->stats.maxHitPoints = 255;
-   player->stats.maxMagicPoints = 255;
-   SPELL_SET_HASHEAL( player->spells );
-
    Player_UpdateTextColor( player, UINT8_MAX );
 }
 
@@ -83,14 +77,12 @@ uint16_t Player_CollectExperience( Player_t* player, uint16_t experience )
    return Math_CollectAmount16u( &( player->experience ), experience );
 }
 
-uint8_t Player_RestoreHitPoints( Player_t* player, uint8_t hitPoints )
+void Player_RestoreHitPoints( Player_t* player, uint8_t hitPoints )
 {
-   uint8_t amount;
    uint8_t previousHitPoints = player->stats.hitPoints;
 
-   amount = Math_CollectAmount8u( &( player->stats.hitPoints ), hitPoints );
+   Math_CollectAmount8u( &( player->stats.hitPoints ), hitPoints );
    Player_UpdateTextColor( player, previousHitPoints );
-   return amount;
 }
 
 Bool_t Player_CollectItem( Player_t* player, Item_t item )

--- a/DragonQuestino/player.c
+++ b/DragonQuestino/player.c
@@ -197,7 +197,7 @@ internal void Player_UpdateTextColor( Player_t* player, uint8_t previousHitPoint
 
    if ( percentage < PLAYER_LOWHEALTH_PERCENTAGE && previousPercentage >= PLAYER_LOWHEALTH_PERCENTAGE )
    {
-      player->screen->textColor = COLOR_RED;
+      player->screen->textColor = COLOR_INJUREDRED;
       player->screen->needsRedraw = True;
    }
    else if ( percentage >= PLAYER_LOWHEALTH_PERCENTAGE && previousPercentage < PLAYER_LOWHEALTH_PERCENTAGE )

--- a/DragonQuestino/player.h
+++ b/DragonQuestino/player.h
@@ -8,6 +8,8 @@
 typedef struct Screen_t Screen_t;
 typedef struct TileMap_t TileMap_t;
 
+#define PLAYER_LOWHEALTH_PERCENTAGE             0.2f
+
 #define SPELL_HAS_HEAL( x )                     ( ( x ) & 0x1 )
 #define SPELL_HAS_SIZZ( x )                     ( ( x ) & 0x2 )
 #define SPELL_HAS_SLEEP( x )                    ( ( x ) & 0x4 )

--- a/DragonQuestino/player.h
+++ b/DragonQuestino/player.h
@@ -207,7 +207,7 @@ uint16_t Player_GetLevel( Player_t* player );
 uint16_t Player_GetExperienceRemaining( Player_t* player );
 uint16_t Player_CollectGold( Player_t* player, uint16_t gold );
 uint16_t Player_CollectExperience( Player_t* player, uint16_t experience );
-uint8_t Player_RestoreHitPoints( Player_t* player, uint8_t hitPoints );
+void Player_RestoreHitPoints( Player_t* player, uint8_t hitPoints );
 Bool_t Player_CollectItem( Player_t* player, Item_t item );
 void Player_SetCursed( Player_t* player, Bool_t cursed );
 void Player_SetHolyProtection( Player_t* player, Bool_t hasHolyProtection);

--- a/DragonQuestino/screen.c
+++ b/DragonQuestino/screen.c
@@ -8,6 +8,7 @@ void Screen_Init( Screen_t* screen, uint16_t* buffer )
    Screen_LoadPalette( screen );
    Screen_LoadTextBitFields( screen );
    screen->textColor = COLOR_WHITE;
+   screen->needsRedraw = False;
 }
 
 void Screen_BackupPalette( Screen_t* screen )

--- a/DragonQuestino/screen.h
+++ b/DragonQuestino/screen.h
@@ -13,6 +13,7 @@
 #define COLOR_GREEN                    0x07E0
 #define COLOR_BLUE                     0x001F
 #define COLOR_GROSSYELLOW              0x7BA1
+#define COLOR_INJUREDRED               0xDA8A
 
 #define TEXT_TILE_COUNT                85
 #define TEXT_TILE_SIZE                 8

--- a/DragonQuestino/screen.h
+++ b/DragonQuestino/screen.h
@@ -38,6 +38,7 @@ typedef struct Screen_t
    uint16_t backupPalette[PALETTE_COLORS];
    uint8_t textBitFields[TEXT_TILE_COUNT][TEXT_TILE_SIZE];
    uint16_t textColor;
+   Bool_t needsRedraw;
 }
 Screen_t;
 

--- a/DragonQuestinoWinDev/DragonQuestinoWinDev/win_main.c
+++ b/DragonQuestinoWinDev/DragonQuestinoWinDev/win_main.c
@@ -231,7 +231,7 @@ internal void HandleKeyboardInput( uint32_t keyCode, LPARAM flags )
                break;
             case VK_TOGGLECURSED:
                Player_SetCursed( &( g_globals.game.player ), g_globals.game.player.isCursed ? False : True );
-               Game_FlagRedraw( &( g_globals.game ) );
+               g_globals.game.screen.needsRedraw = True;
                break;
          }
       }
@@ -456,7 +456,7 @@ internal void GetAllItems()
       ITEM_TOGGLE_HASCURSEDBELT( g_globals.game.player.items );
    }
 
-   Game_FlagRedraw( &( g_globals.game ) );
+   g_globals.game.screen.needsRedraw = True;
 }
 
 internal void MaxOutStats()
@@ -466,7 +466,7 @@ internal void MaxOutStats()
    g_globals.game.player.experience = UINT16_MAX;
    g_globals.game.player.gold = UINT16_MAX;
 
-   g_globals.game.player.stats.hitPoints = UINT8_MAX;
+   Player_RestoreHitPoints( &( g_globals.game.player ), UINT8_MAX );
    g_globals.game.player.stats.maxHitPoints = UINT8_MAX;
    g_globals.game.player.stats.magicPoints = UINT8_MAX;
    g_globals.game.player.stats.maxMagicPoints = UINT8_MAX;
@@ -483,5 +483,5 @@ internal void MaxOutStats()
       Menu_Reset( &( g_globals.game.menus[i] ) );
    }
 
-   Game_FlagRedraw( &( g_globals.game ) );
+   g_globals.game.screen.needsRedraw = True;
 }


### PR DESCRIPTION
## Overview

This changes the color of the text from white to red when the player's health drops below 20% (and vice-versa), unless there's a curse, in which case nothing should happen.