### PR TITLE
Fix glowing and holy protection

### DIFF
--- a/DragonQuestino/dialog.c
+++ b/DragonQuestino/dialog.c
@@ -249,6 +249,7 @@ internal uint32_t Dialog_GetMessageSectionCount( Dialog_t* dialog )
       case DialogId_Use_WingCantUse:
       case DialogId_Use_Wing:
       case DialogId_Use_TorchCantUse:
+      case DialogId_Use_TorchAlreadyUsed:
       case DialogId_Use_Torch:
       case DialogId_Use_GwaelynsLoveCantUse:
       case DialogId_Use_RainbowDropCantUse:
@@ -386,6 +387,7 @@ internal void Dialog_GetMessageText( Dialog_t* dialog, char* text )
          }
       case DialogId_Use_WingCantUse: strcpy( text, STRING_ITEMUSE_WING_CANTUSE ); return;
       case DialogId_Use_TorchCantUse: strcpy( text, STRING_ITEMUSE_TORCH_CANTUSE ); return;
+      case DialogId_Use_TorchAlreadyUsed: strcpy( text, STRING_ITEMUSE_TORCH_ALREADYUSED ); return;
       case DialogId_Use_Torch: strcpy( text, STRING_ITEMUSE_TORCH ); return;
       case DialogId_Use_FairyFlute:
          switch ( dialog->section )

--- a/DragonQuestino/enums.h
+++ b/DragonQuestino/enums.h
@@ -201,6 +201,7 @@ typedef enum DialogId_t
    DialogId_Use_FairyWaterCursed,
    DialogId_Use_FairyWater,
    DialogId_Use_TorchCantUse,
+   DialogId_Use_TorchAlreadyUsed,
    DialogId_Use_Torch,
    DialogId_Use_FairyFlute,
    DialogId_Use_SilverHarp,

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -126,7 +126,6 @@ void Game_ChangeMainState( Game_t* game, MainState_t newState )
          break;
       case MainState_Battle:
          game->screen.needsRedraw = True;
-         Battle_Generate( &( game->battle ) );
          Animation_Start( &( game->animation ), AnimationId_Battle_Checkerboard );
          break;
    }

--- a/DragonQuestino/game_items.c
+++ b/DragonQuestino/game_items.c
@@ -46,15 +46,22 @@ void Game_UseTorch( Game_t* game )
 {
    if ( game->tileMap.isDark )
    {
-      if ( game->tileMap.glowDiameter <= TORCH_DIAMETER )
+      if ( game->tileMap.torchIsLit )
       {
-         TileMap_SetTargetGlowDiameter( &( game->tileMap ), TORCH_DIAMETER );
-         game->tileMap.glowTileCount = 0;
-         TileMap_StartGlowTransition( &( game->tileMap ) );
+         Game_OpenDialog( game, DialogId_Use_TorchAlreadyUsed );
       }
+      else
+      {
+         if ( game->tileMap.glowDiameter <= TORCH_DIAMETER )
+         {
+            TileMap_SetTargetGlowDiameter( &( game->tileMap ), TORCH_DIAMETER );
+            game->tileMap.torchIsLit = True;
+            TileMap_StartGlowTransition( &( game->tileMap ) );
+         }
 
-      ITEM_SET_TORCHCOUNT( game->player.items, ITEM_GET_TORCHCOUNT( game->player.items ) - 1 );
-      Game_OpenDialog( game, DialogId_Use_Torch );
+         ITEM_SET_TORCHCOUNT( game->player.items, ITEM_GET_TORCHCOUNT( game->player.items ) - 1 );
+         Game_OpenDialog( game, DialogId_Use_Torch );
+      }
    }
    else
    {

--- a/DragonQuestino/game_physics.c
+++ b/DragonQuestino/game_physics.c
@@ -180,6 +180,7 @@ void Game_PlayerSteppedOnTile( Game_t* game, uint32_t tileIndex )
 
    if ( game->battle.specialEnemy != SpecialEnemy_None )
    {
+      Battle_Generate( &( game->battle ) );
       Game_ChangeMainState( game, MainState_Battle );
    }
    else if ( game->tileMap.hasEncounters )
@@ -187,17 +188,9 @@ void Game_PlayerSteppedOnTile( Game_t* game, uint32_t tileIndex )
       if ( game->player.hasHolyProtection )
       {
          game->player.holyProtectionSteps++;
+      }
 
-         if ( game->player.holyProtectionSteps >= HOLY_PROTECTION_MAX_STEPS )
-         {
-            game->player.hasHolyProtection = False;
-            Game_OpenDialog( game, DialogId_HolyProtection_Off );
-         }
-      }
-      else
-      {
-         Game_RollEncounter( game, tileIndex );
-      }
+      Game_RollEncounter( game, tileIndex );
    }
 }
 
@@ -230,7 +223,20 @@ internal void Game_RollEncounter( Game_t* game, uint32_t tileIndex )
 
    if ( spawnEncounter )
    {
-      Game_ChangeMainState( game, MainState_Battle );
+      Battle_Generate( &( game->battle ) );
+
+      if ( !( game->player.hasHolyProtection ) || game->battle.enemy.stats.strength > ( game->player.stats.agility / 2 ) )
+      {
+         Game_ChangeMainState( game, MainState_Battle );
+      }
+   }
+   else
+   {
+      if ( game->player.hasHolyProtection && game->player.holyProtectionSteps >= HOLY_PROTECTION_MAX_STEPS )
+      {
+         game->player.hasHolyProtection = False;
+         Game_OpenDialog( game, DialogId_HolyProtection_Off );
+      }
    }
 }
 

--- a/DragonQuestino/game_physics.c
+++ b/DragonQuestino/game_physics.c
@@ -160,7 +160,9 @@ void Game_PlayerSteppedOnTile( Game_t* game, uint32_t tileIndex )
    {
       game->tileMap.glowTileCount++;
 
-      if ( game->tileMap.glowTileCount > GLOW_MAX_TILES )
+      if ( ( game->tileMap.glowDiameter == 7 && game->tileMap.glowTileCount > GLOW_THREERADIUS_TILES ) ||
+           ( game->tileMap.glowDiameter == 5 && game->tileMap.glowTileCount > GLOW_TWORADIUS_TILES ) ||
+           ( game->tileMap.glowDiameter == 3 && game->tileMap.glowTileCount > GLOW_ONERADIUS_TILES ) )
       {
          game->tileMap.glowTileCount = 0;
          TileMap_ReduceTargetGlowDiameter( &( game->tileMap ) );

--- a/DragonQuestino/game_physics.c
+++ b/DragonQuestino/game_physics.c
@@ -185,7 +185,7 @@ void Game_PlayerSteppedOnTile( Game_t* game, uint32_t tileIndex )
    }
    else if ( game->tileMap.hasEncounters )
    {
-      if ( game->player.hasHolyProtection )
+      if ( !( game->tileMap.isDungeon ) && game->player.hasHolyProtection )
       {
          game->player.holyProtectionSteps++;
       }
@@ -225,7 +225,7 @@ internal void Game_RollEncounter( Game_t* game, uint32_t tileIndex )
    {
       Battle_Generate( &( game->battle ) );
 
-      if ( !( game->player.hasHolyProtection ) || game->battle.enemy.stats.strength > ( game->player.stats.agility / 2 ) )
+      if ( game->tileMap.isDungeon || !( game->player.hasHolyProtection ) || game->battle.enemy.stats.strength > ( game->player.stats.agility / 2 ) )
       {
          Game_ChangeMainState( game, MainState_Battle );
       }

--- a/DragonQuestino/game_spells.c
+++ b/DragonQuestino/game_spells.c
@@ -36,6 +36,7 @@ void Game_CastGlow( Game_t* game )
 
       if ( game->player.isCursed )
       {
+         game->tileMap.torchIsLit = False;
          TileMap_SetTargetGlowDiameter( &( game->tileMap ), 1 );
          Game_OpenDialog( game, DialogId_Spell_OverworldCastGlowCursed );
       }

--- a/DragonQuestino/strings.h
+++ b/DragonQuestino/strings.h
@@ -120,6 +120,7 @@
 #define STRING_ITEMUSE_FAIRYWATER                                    "You drink a vial of fairy water."
 #define STRING_ITEMUSE_WING_CANTUSE                                  "You cannot use a Chimaera wing here."
 #define STRING_ITEMUSE_TORCH_CANTUSE                                 "You cannot use a torch here."
+#define STRING_ITEMUSE_TORCH_ALREADYUSED                             "A torch has already been lit."
 #define STRING_ITEMUSE_TORCH                                         "You light a torch."
 #define STRING_ITEMUSE_FAIRYFLUTE_1                                  "You play the Fairy Flute."
 #define STRING_ITEMUSE_FAIRYFLUTE_2                                  "A mysterious melody fills the air."

--- a/DragonQuestino/tile_map.c
+++ b/DragonQuestino/tile_map.c
@@ -30,6 +30,7 @@ void TileMap_Init( TileMap_t* tileMap, Screen_t* screen, GameFlags_t* gameFlags,
    tileMap->blocksMagic = False;
    tileMap->isDungeon = False;
    tileMap->isDark = False;
+   tileMap->torchIsLit = False;
 }
 
 void TileMap_Tic( TileMap_t* tileMap )
@@ -66,6 +67,7 @@ void TileMap_ResetViewport( TileMap_t* tileMap )
    tileMap->viewportScreenPos.y = 0;
    tileMap->glowDiameter = 1;
    tileMap->targetGlowDiameter = 1;
+   tileMap->torchIsLit = False;
 
    TileMap_UpdateViewport( tileMap );
 }
@@ -243,7 +245,11 @@ internal void TileMap_SetGlowDiameter( TileMap_t* tileMap, uint32_t diameter )
 
 internal void TileMap_ReduceGlowDiameter( TileMap_t* tileMap )
 {
-   if ( tileMap->glowDiameter > tileMap->targetGlowDiameter )
+   if ( tileMap->glowDiameter == 3 && tileMap->torchIsLit )
+   {
+      tileMap->targetGlowDiameter = 3;
+   }
+   else if ( tileMap->glowDiameter > tileMap->targetGlowDiameter )
    {
       TileMap_SetGlowDiameter( tileMap, tileMap->glowDiameter - 2 );
    }

--- a/DragonQuestino/tile_map.h
+++ b/DragonQuestino/tile_map.h
@@ -41,7 +41,9 @@
 
 #define TORCH_DIAMETER                          3
 #define GLOW_SPELL_DIAMETER                     7
-#define GLOW_MAX_TILES                          200
+#define GLOW_THREERADIUS_TILES                  80
+#define GLOW_TWORADIUS_TILES                    60
+#define GLOW_ONERADIUS_TILES                    60
 #define GLOW_TRANSITION_FRAME_SECONDS           0.1f
 
 #define TILEMAP_OVERWORLD_ID                    0

--- a/DragonQuestino/tile_map.h
+++ b/DragonQuestino/tile_map.h
@@ -122,6 +122,7 @@ typedef struct TileMap_t
    Bool_t blocksMagic;
    Bool_t isDungeon;
    Bool_t isDark;
+   Bool_t torchIsLit;
    uint32_t glowDiameter;
    uint32_t targetGlowDiameter;
    uint32_t glowTileCount;

--- a/DragonQuestinoWinDev/DragonQuestinoWinDev/win_main.c
+++ b/DragonQuestinoWinDev/DragonQuestinoWinDev/win_main.c
@@ -2,6 +2,7 @@
 
 #include "win_common.h"
 #include "game.h"
+#include "tables.h"
 
 internal void FatalError( const char* message );
 internal LRESULT CALLBACK MainWindowProc( _In_ HWND hWnd, _In_ UINT uMsg, _In_ WPARAM wParam, _In_ LPARAM lParam );
@@ -478,6 +479,7 @@ internal void MaxOutStats()
 {
    uint32_t i;
 
+   g_globals.game.player.level = STAT_TABLE_SIZE - 1;
    g_globals.game.player.experience = UINT16_MAX;
    g_globals.game.player.gold = UINT16_MAX;
 


### PR DESCRIPTION
## Overview

This was meant to make sure the ranges of spell-based healing/hurting were correct, but it turns out those were already correct. Instead, this fixes a few things regarding glowing and holy protection:

- If you light a torch in a dungeon, it should never go out. Even if you cast Glow, the torch should still be lit when it runs out.
- Glow is supposed to decay a LOT faster. It should be 80 tiles for the maximum radius, then 60 tiles for each of the next two.
- Holy protection should only work if you're stronger than the potential enemy encounter.
- Holy protection should never work in dungeons.