### PR TITLE
Implemented battle items

### DIFF
--- a/DragonQuestino/enums.h
+++ b/DragonQuestino/enums.h
@@ -132,6 +132,7 @@ typedef enum MenuId_t
 
    MenuId_Battle,
    MenuId_BattleSpell,
+   MenuId_BattleItem,
 
    MenuId_Count
 }

--- a/DragonQuestino/game.h
+++ b/DragonQuestino/game.h
@@ -101,6 +101,7 @@ void Game_CastZoom( Game_t* game, uint32_t townId );
 void Game_CastRepel( Game_t* game );
 void Game_CastMidheal( Game_t* game );
 void Game_CastSizzle( Game_t* game );
+void Game_SpellSleepSuccessCallback( Game_t* game );
 
 // game_items.c
 void Game_UseHerb( Game_t* game );

--- a/DragonQuestino/game_input.c
+++ b/DragonQuestino/game_input.c
@@ -312,6 +312,8 @@ internal void Game_HandleBattleMenuInput( Game_t* game )
          case MenuCommand_Spell_Fizzle: Game_CastFizzle( game ); break;
          case MenuCommand_Spell_Midheal: Game_CastMidheal( game ); break;
          case MenuCommand_Spell_Sizzle: Game_CastSizzle( game ); break;
+
+         case MenuCommand_Item_Herb: Game_UseHerb( game ); break;
       }
    }
    else if ( game->input.buttonStates[Button_B].pressed )

--- a/DragonQuestino/game_input.c
+++ b/DragonQuestino/game_input.c
@@ -13,6 +13,7 @@ internal void Game_OpenZoomMenu( Game_t* game );
 internal void Game_HandleBattleMenuInput( Game_t* game );
 internal void Game_HandleBattleDialogInput( Game_t* game );
 internal void Game_OpenBattleSpellMenu( Game_t* game );
+internal void Game_OpenBattleItemMenu( Game_t* game );
 
 void Game_HandleInput( Game_t* game )
 {
@@ -303,7 +304,7 @@ internal void Game_HandleBattleMenuInput( Game_t* game )
          case MenuCommand_Battle_Attack: Battle_AttemptAttack( &( game->battle ) ); break;
          case MenuCommand_Battle_Flee: Battle_AttemptFlee( &( game->battle ) ); break;
          case MenuCommand_Battle_Spell: Game_OpenBattleSpellMenu( game ); break;
-         case MenuCommand_Battle_Item: Game_ChangeToOverworldState( game ); break;
+         case MenuCommand_Battle_Item: Game_OpenBattleItemMenu( game ); break;
 
          case MenuCommand_Spell_Heal: Game_CastHeal( game ); break;
          case MenuCommand_Spell_Sizz: Game_CastSizz( game ); break;
@@ -318,6 +319,7 @@ internal void Game_HandleBattleMenuInput( Game_t* game )
       switch ( game->activeMenu->id )
       {
          case MenuId_BattleSpell:
+         case MenuId_BattleItem:
             game->activeMenu = &( game->menus[MenuId_Battle] );
             game->screen.needsRedraw = True;
             break;
@@ -370,6 +372,26 @@ internal void Game_OpenBattleSpellMenu( Game_t* game )
       // this is impossible in normal gameplay, but we'll account for it anyway
       Dialog_Reset( &( game->dialog ) );
       Dialog_PushSectionWithCallback( &( game->dialog ), STRING_BATTLE_CANTCASTSPELL, Game_ResetBattleMenu, game );
+      Game_OpenDialog( game );
+   }
+}
+
+internal void Game_OpenBattleItemMenu( Game_t* game )
+{
+   if ( !game->player.items )
+   {
+      Dialog_Reset( &( game->dialog ) );
+      Dialog_PushSectionWithCallback( &( game->dialog ), STRING_BATTLE_NOITEMS, Game_ResetBattleMenu, game );
+      Game_OpenDialog( game );
+   }
+   else if ( ITEM_GET_BATTLEUSEABLECOUNT( game->player.items ) )
+   {
+      Game_OpenMenu( game, MenuId_BattleItem );
+   }
+   else
+   {
+      Dialog_Reset( &( game->dialog ) );
+      Dialog_PushSectionWithCallback( &( game->dialog ), STRING_BATTLE_CANTUSEITEM, Game_ResetBattleMenu, game );
       Game_OpenDialog( game );
    }
 }

--- a/DragonQuestino/game_input.c
+++ b/DragonQuestino/game_input.c
@@ -314,6 +314,7 @@ internal void Game_HandleBattleMenuInput( Game_t* game )
          case MenuCommand_Spell_Sizzle: Game_CastSizzle( game ); break;
 
          case MenuCommand_Item_Herb: Game_UseHerb( game ); break;
+         case MenuCommand_Item_FairyFlute: Game_UseFairyFlute( game ); break;
       }
    }
    else if ( game->input.buttonStates[Button_B].pressed )

--- a/DragonQuestino/game_items.c
+++ b/DragonQuestino/game_items.c
@@ -6,6 +6,8 @@ internal void Game_UseWingCallback( Game_t* game );
 internal void Game_UseRainbowDropCallback( Game_t* game );
 internal void Game_RainbowDropTrippyCallback( Game_t* game );
 internal void Game_UseSilverHarpCallback( Game_t* game );
+internal void Game_UseFairyFluteCallback( Game_t* game );
+internal void Game_UseFairyFluteMessageCallback( Game_t* game );
 
 void Game_UseHerb( Game_t* game )
 {
@@ -118,7 +120,16 @@ void Game_UseFairyFlute( Game_t* game )
    game->screen.needsRedraw = True;
    Dialog_Reset( &( game->dialog ) );
    Dialog_PushSection( &( game->dialog ), STRING_ITEMUSE_FAIRYFLUTE_1 );
-   Dialog_PushSection( &( game->dialog ), STRING_ITEMUSE_FAIRYFLUTE_2 );
+
+   if ( game->mainState == MainState_Battle )
+   {
+      Dialog_PushSectionWithCallback( &( game->dialog ), STRING_ITEMUSE_FAIRYFLUTE_2, Game_UseFairyFluteCallback, game );
+   }
+   else
+   {
+      Dialog_PushSection( &( game->dialog ), STRING_ITEMUSE_FAIRYFLUTE_2 );
+   }
+
    Game_OpenDialog( game );
 }
 
@@ -263,5 +274,31 @@ internal void Game_UseSilverHarpCallback( Game_t* game )
       AnimationChain_PushAnimation( &( game->animationChain ), AnimationId_Pause );
       AnimationChain_PushAnimationWithCallback( &( game->animationChain ), AnimationId_Pause, Game_ChangeToBattleState, game );
       AnimationChain_Start( &( game->animationChain ) );
+   }
+}
+
+internal void Game_UseFairyFluteCallback( Game_t* game )
+{
+   AnimationChain_Reset( &( game->animationChain ) );
+   AnimationChain_PushAnimation( &( game->animationChain ), AnimationId_Pause );
+   AnimationChain_PushAnimation( &( game->animationChain ), AnimationId_Pause );
+   AnimationChain_PushAnimation( &( game->animationChain ), AnimationId_Pause );
+   AnimationChain_PushAnimation( &( game->animationChain ), AnimationId_Pause );
+   AnimationChain_PushAnimation( &( game->animationChain ), AnimationId_Pause );
+   AnimationChain_PushAnimationWithCallback( &( game->animationChain ), AnimationId_Pause, Game_UseFairyFluteMessageCallback, game );
+   AnimationChain_Start( &( game->animationChain ) );
+}
+
+internal void Game_UseFairyFluteMessageCallback( Game_t* game )
+{
+   if ( game->battle.specialEnemy == SpecialEnemy_Golem && !game->battle.enemy.stats.isAsleep )
+   {
+      Game_SpellSleepSuccessCallback( game );
+   }
+   else
+   {
+      Dialog_Reset( &( game->dialog ) );
+      Dialog_PushSectionWithCallback( &( game->dialog ), STRING_BUTNOTHINGHAPPENS, Game_ResetBattleMenu, game );
+      Game_OpenDialog( game );
    }
 }

--- a/DragonQuestino/game_items.c
+++ b/DragonQuestino/game_items.c
@@ -17,7 +17,10 @@ void Game_UseHerb( Game_t* game )
 
    if ( game->player.stats.hitPoints == game->player.stats.maxHitPoints )
    {
-      Dialog_PushSection( &( game->dialog ), STRING_FULLYHEALED );
+      Dialog_PushSectionWithCallback( &( game->dialog ),
+                                      ( game->mainState == MainState_Overworld ) ? STRING_FULLYHEALED : STRING_BATTLE_FULLYHEALED,
+                                      ( game->mainState == MainState_Overworld ) ? 0 : Game_ResetBattleMenu,
+                                      ( game->mainState == MainState_Overworld ) ? 0 : game );
    }
    else
    {

--- a/DragonQuestino/game_spells.c
+++ b/DragonQuestino/game_spells.c
@@ -13,7 +13,6 @@ internal void Game_CastSpellCallback( Game_t* game );
 internal void Game_SpellHealCallback( Game_t* game );
 internal void Game_SpellHurtCallback( Game_t* game );
 internal void Game_SpellSleepCallback( Game_t* game );
-internal void Game_SpellSleepSuccessCallback( Game_t* game );
 internal void Game_SpellFizzleCallback( Game_t* game );
 internal void Game_SpellFizzleSuccessCallback( Game_t* game );
 internal void Game_SpellZoomCallback( Game_t* game );
@@ -256,6 +255,17 @@ void Game_CastSizzle( Game_t* game )
    Game_OpenDialog( game );
 }
 
+void Game_SpellSleepSuccessCallback( Game_t* game )
+{
+   char msg[64];
+
+   game->battle.enemy.stats.isAsleep = True;
+   Dialog_Reset( &( game->dialog ) );
+   sprintf( msg, STRING_BATTLE_ENEMYASLEEP, game->battle.enemy.name );
+   Dialog_PushSectionWithCallback( &( game->dialog ), msg, Game_ResetBattleMenu, game );
+   Game_OpenDialog( game );
+}
+
 internal Bool_t Game_CanCastSpell( Game_t* game, uint8_t requiredMp, const char* spellName )
 {
    char msg[64];
@@ -424,17 +434,6 @@ internal void Game_SpellSleepCallback( Game_t* game )
       AnimationChain_PushAnimationWithCallback( &( game->animationChain ), AnimationId_Pause, Game_SpellSleepSuccessCallback, game );
       AnimationChain_Start( &( game->animationChain ) );
    }
-}
-
-internal void Game_SpellSleepSuccessCallback( Game_t* game )
-{
-   char msg[64];
-
-   game->battle.enemy.stats.isAsleep = True;
-   Dialog_Reset( &( game->dialog ) );
-   sprintf( msg, STRING_BATTLE_ENEMYASLEEP, game->battle.enemy.name );
-   Dialog_PushSectionWithCallback( &( game->dialog ), msg, Game_ResetBattleMenu, game );
-   Game_OpenDialog( game );
 }
 
 internal void Game_SpellFizzleCallback( Game_t* game )

--- a/DragonQuestino/menu.c
+++ b/DragonQuestino/menu.c
@@ -12,6 +12,7 @@ internal void Menu_UpdateOverworldSpell( Menu_t* menu );
 internal void Menu_UpdateOverworldItem( Menu_t* menu );
 internal void Menu_UpdateZoom( Menu_t* menu );
 internal void Menu_UpdateBattleSpell( Menu_t* menu );
+internal void Menu_UpdateBattleItem( Menu_t* menu );
 
 void Menu_Init( Menu_t* menu, MenuId_t id, Screen_t* screen, Player_t* player, TileMap_t* tileMap )
 {
@@ -155,6 +156,7 @@ internal void Menu_Update( Menu_t* menu )
       case MenuId_OverworldItem: Menu_UpdateOverworldItem( menu ); break;
       case MenuId_Zoom: Menu_UpdateZoom( menu ); break;
       case MenuId_BattleSpell: Menu_UpdateBattleSpell( menu ); break;
+      case MenuId_BattleItem: Menu_UpdateBattleItem( menu ); break;
    }
 }
 
@@ -522,5 +524,43 @@ internal void Menu_UpdateBattleSpell( Menu_t* menu )
    {
       sprintf( menu->items[i].text, STRING_SPELL_SIZZLE );
       menu->items[i].command = MenuCommand_Spell_Sizzle;
+   }
+}
+
+internal void Menu_UpdateBattleItem( Menu_t* menu )
+{
+   uint32_t i;
+   uint32_t items = menu->player->items;
+
+   strcpy( menu->title, STRING_BATTLE_MENU_ITEM );
+
+   menu->itemCount = ITEM_GET_BATTLEUSEABLECOUNT( items );
+   menu->itemsPerColumn = menu->itemCount;
+   menu->selectedIndex = 0;
+   menu->position.x = 136;
+   menu->position.y = 32;
+   menu->borderSize.x = 12;
+   menu->borderSize.y = (uint16_t)( ( menu->itemCount * 2 ) + 3 );
+   menu->borderPadding.x = 1;
+   menu->borderPadding.y = 1;
+   menu->columnWidth = 10;
+   menu->itemPadding = 1;
+   menu->caratOffset = 1;
+
+   i = 0;
+
+   if ( ITEM_GET_HERBCOUNT( items ) )
+   {
+      menu->items[i].twoLineText = False;
+      sprintf( menu->items[i].text, STRING_OVERWORLD_ITEMMENU_HERB, ITEM_GET_HERBCOUNT( items ) );
+      menu->items[i].command = MenuCommand_Item_Herb;
+      i++;
+   }
+   if ( ITEM_HAS_FAIRYFLUTE( items ) )
+   {
+      menu->items[i].twoLineText = True;
+      strcpy( menu->items[i].text, STRING_OVERWORLD_ITEMMENU_FAIRYFLUTE_1 );
+      strcpy( menu->items[i].text + MENU_LINE_LENGTH, STRING_OVERWORLD_ITEMMENU_FAIRYFLUTE_2 );
+      menu->items[i].command = MenuCommand_Item_FairyFlute;
    }
 }

--- a/DragonQuestino/player.h
+++ b/DragonQuestino/player.h
@@ -103,6 +103,10 @@ typedef struct TileMap_t TileMap_t;
                                                 ( ITEM_HAS_RAINBOWDROP( x ) ? 1 : 0 ) + \
                                                 ( ITEM_HAS_CURSEDBELT( x ) ? 1 : 0 ) )
 
+#define ITEM_GET_BATTLEUSEABLECOUNT( x )        ( 0 + \
+                                                ( ITEM_GET_HERBCOUNT( x ) ? 1 : 0 ) + \
+                                                ( ITEM_HAS_FAIRYFLUTE( x ) ? 1 : 0 ) )
+
 #define ITEM_GET_MAPNONUSEABLECOUNT( x )        ( 0 + \
                                                 ( ITEM_GET_KEYCOUNT( x ) ? 1 : 0 ) + \
                                                 ( ITEM_HAS_STONEOFSUNLIGHT( x ) ? 1 : 0 ) + \

--- a/DragonQuestino/strings.h
+++ b/DragonQuestino/strings.h
@@ -225,6 +225,8 @@
 #define STRING_BATTLE_SPELL_NOEFFECT                                 "But the spell has no effect on the %s!"
 #define STRING_BATTLE_SPELL_SLEEP_ALREADYASLEEP                      "The %s is already asleep. Command?"
 #define STRING_BATTLE_SPELL_FIZZLE_ALREADYFIZZLED                    "The %s's spells are already blocked. Command?"
+#define STRING_BATTLE_NOITEMS                                        "You do not have any items. Command?"
+#define STRING_BATTLE_CANTUSEITEM                                    "You do not have any items that can be used in battle. Command?"
 
 #define STRING_BATTLE_MENU_TITLE                                     "COMMAND"
 #define STRING_BATTLE_MENU_ATTACK                                    "ATTACK"


### PR DESCRIPTION
## Overview

This allows you to use herbs and the fairy flute during battle. Herbs are simple, they act just like healing spells, but the fairy flue is a bit different:

- Using it on a regular enemy doesn't do anything at all
- Using it on the Golem puts it to sleep
- Using it on the Golem when it's already asleep doesn't do anything, but also wastes a turn