### PR TITLE
Implement damage from tiles

### DIFF
--- a/DragonQuestino/battle.c
+++ b/DragonQuestino/battle.c
@@ -183,8 +183,7 @@ internal uint32_t Battle_GenerateEnemyIndex( Battle_t* battle )
 {
    TileMap_t* tileMap = &( battle->game->tileMap );
    Player_t* player = &( battle->game->player );
-   uint32_t adjustedTileIndex = player->tileIndex + ( ( player->tileIndex / tileMap->tilesX ) * ( TILE_COUNT_X - tileMap->tilesX ) );
-   uint32_t enemyPoolIndex = TILE_GET_ENEMYPOOLINDEX( tileMap->tiles[adjustedTileIndex] );
+   uint32_t enemyPoolIndex = TILE_GET_ENEMYPOOLINDEX( tileMap->tiles[player->canonicalTileIndex] );
    uint32_t i, enemyIndex;
 
    if ( tileMap->isDungeon )

--- a/DragonQuestino/game.h
+++ b/DragonQuestino/game.h
@@ -76,7 +76,7 @@ void Game_HandleInput( Game_t* game );
 
 // game_physics.c
 void Game_TicPhysics( Game_t* game );
-void Game_PlayerSteppedOnTile( Game_t* game, uint32_t tileIndex );
+void Game_PlayerSteppedOnTile( Game_t* game );
 
 // game_render.c
 void Game_Draw( Game_t* game );

--- a/DragonQuestino/game_actions.c
+++ b/DragonQuestino/game_actions.c
@@ -236,5 +236,5 @@ internal void Game_FoundHiddenStairsCallback( Game_t* game )
 
 internal void Game_TakeHiddenStairsCallback( Game_t* game )
 {
-   Game_PlayerSteppedOnTile( game, TILEMAP_HIDDENSTAIRS_INDEX );
+   Game_PlayerSteppedOnTile( game );
 }

--- a/DragonQuestino/game_render.c
+++ b/DragonQuestino/game_render.c
@@ -133,7 +133,11 @@ void Game_Draw( Game_t* game )
 void Game_DrawOverworld( Game_t* game )
 {
    Game_DrawTileMap( game );
-   Game_DrawPlayer( game );
+
+   if ( !( game->player.sprite.flickerOff ) )
+   {
+      Game_DrawPlayer( game );
+   }
 
    if ( game->subState == SubState_None && game->overworldInactivitySeconds > OVERWORLD_INACTIVE_STATUS_SECONDS )
    {

--- a/DragonQuestino/player.c
+++ b/DragonQuestino/player.c
@@ -9,6 +9,7 @@ void Player_Init( Player_t* player, TileMap_t* tileMap )
    player->tileMap = tileMap;
 
    player->tileIndex = 148; // sort of in front of King Lorik
+   Player_SetCanonicalTileIndex( player );
    player->sprite.position.x = (float)( TILE_SIZE * 8 );
    player->sprite.position.y = (float)( TILE_SIZE * 7 );
    player->velocity.x = 0.0f;
@@ -19,14 +20,14 @@ void Player_Init( Player_t* player, TileMap_t* tileMap )
    player->spriteOffset.x = -2;
    player->spriteOffset.y = -4;
    player->sprite.direction = Direction_Down;
+   player->sprite.isFlickering = False;
    strcpy( player->name, "Ed209" );
    player->isCursed = False;
    player->hasHolyProtection = False;
    player->holyProtectionSteps = 0;
    player->townsVisited = 0;
 
-   // MUFFINS: for testing
-   player->experience = 30001;
+   player->experience = 0;
    player->gold = 0;
    player->items = 0;
    player->spells = 0;
@@ -44,19 +45,9 @@ void Player_Init( Player_t* player, TileMap_t* tileMap )
    player->stats.hurtResist = 0;
    player->stats.dodge = 1;
 
-   Player_LoadWeapon( player, WEAPON_BROADSWORD_ID );
-   Player_LoadArmor( player, ARMOR_HALFPLATE_ID );
-   Player_LoadShield( player, SHIELD_LARGESHIELD_ID );
-
-   player->townsVisited = 0xFF;
-
-   ITEM_SET_HERBCOUNT( player->items, 3 );
-   ITEM_SET_KEYCOUNT( player->items, ITEM_MAXKEYS );
-   ITEM_SET_TORCHCOUNT( player->items, ITEM_MAXTORCHES );
-   ITEM_SET_FAIRYWATERCOUNT( player->items, 2 );
-   ITEM_SET_WINGCOUNT( player->items, 2 );
-   ITEM_TOGGLE_HASGWAELYNSLOVE( player->items );
-   ITEM_TOGGLE_HASRAINBOWDROP( player->items );
+   Player_LoadWeapon( player, WEAPON_NONE_ID );
+   Player_LoadArmor( player, ARMOR_NONE_ID );
+   Player_LoadShield( player, SHIELD_NONE_ID );
 }
 
 uint8_t Player_GetLevelFromExperience( Player_t* player )
@@ -252,4 +243,9 @@ void Player_LoadShield( Player_t* player, uint32_t shieldId )
       case SHIELD_LARGESHIELD_ID: strcpy( player->shield.name1, STRING_SHIELD_LARGE1 ); strcpy( player->shield.name2, STRING_SHIELD_LARGE2 ); break;
       case SHIELD_SILVERSHIELD_ID: strcpy( player->shield.name1, STRING_SHIELD_SILVER1 ); strcpy( player->shield.name2, STRING_SHIELD_SILVER2 ); break;
    }
+}
+
+void Player_SetCanonicalTileIndex( Player_t* player )
+{
+   player->canonicalTileIndex = player->tileIndex + ( ( player->tileIndex / player->tileMap->tilesX ) * ( TILE_COUNT_X - player->tileMap->tilesX ) );
 }

--- a/DragonQuestino/player.c
+++ b/DragonQuestino/player.c
@@ -25,7 +25,8 @@ void Player_Init( Player_t* player, TileMap_t* tileMap )
    player->holyProtectionSteps = 0;
    player->townsVisited = 0;
 
-   player->experience = 0;
+   // MUFFINS: for testing
+   player->experience = 30001;
    player->gold = 0;
    player->items = 0;
    player->spells = 0;
@@ -43,9 +44,19 @@ void Player_Init( Player_t* player, TileMap_t* tileMap )
    player->stats.hurtResist = 0;
    player->stats.dodge = 1;
 
-   Player_LoadWeapon( player, WEAPON_NONE_ID );
-   Player_LoadArmor( player, ARMOR_NONE_ID );
-   Player_LoadShield( player, SHIELD_NONE_ID );
+   Player_LoadWeapon( player, WEAPON_BROADSWORD_ID );
+   Player_LoadArmor( player, ARMOR_HALFPLATE_ID );
+   Player_LoadShield( player, SHIELD_LARGESHIELD_ID );
+
+   player->townsVisited = 0xFF;
+
+   ITEM_SET_HERBCOUNT( player->items, 3 );
+   ITEM_SET_KEYCOUNT( player->items, ITEM_MAXKEYS );
+   ITEM_SET_TORCHCOUNT( player->items, ITEM_MAXTORCHES );
+   ITEM_SET_FAIRYWATERCOUNT( player->items, 2 );
+   ITEM_SET_WINGCOUNT( player->items, 2 );
+   ITEM_TOGGLE_HASGWAELYNSLOVE( player->items );
+   ITEM_TOGGLE_HASRAINBOWDROP( player->items );
 }
 
 uint8_t Player_GetLevelFromExperience( Player_t* player )

--- a/DragonQuestino/player.h
+++ b/DragonQuestino/player.h
@@ -197,6 +197,7 @@ typedef struct Player_t
    float maxVelocity;
    Vector2u32_t hitBoxSize;
    uint32_t tileIndex;
+   uint32_t canonicalTileIndex;
    Bool_t isCursed;
    Bool_t hasHolyProtection;
    uint32_t holyProtectionSteps;
@@ -265,6 +266,7 @@ void Player_UpdateSpellsToLevel( Player_t* player, uint8_t level );
 void Player_LoadWeapon( Player_t* player, uint32_t weaponId );
 void Player_LoadArmor( Player_t* player, uint32_t armorId );
 void Player_LoadShield( Player_t* player, uint32_t shieldId );
+void Player_SetCanonicalTileIndex( Player_t* player );
 
 #if defined( __cplusplus )
 }

--- a/DragonQuestino/sprite.c
+++ b/DragonQuestino/sprite.c
@@ -26,3 +26,29 @@ void Sprite_Tic( ActiveSprite_t* sprite )
       }
    }
 }
+
+void Sprite_Flicker( ActiveSprite_t* sprite )
+{
+   if ( sprite->isFlickering )
+   {
+      sprite->elapsedFlickerSeconds += CLOCK_FRAME_SECONDS;
+
+      while ( sprite->elapsedFlickerSeconds > ACTIVE_SPRITE_FLICKER_SECONDS )
+      {
+         sprite->elapsedFlickerSeconds -= ACTIVE_SPRITE_FLICKER_SECONDS;
+         TOGGLE_BOOL( sprite->flickerOff );
+      }
+   }
+   else
+   {
+      sprite->isFlickering = True;
+      sprite->flickerOff = True;
+      sprite->elapsedFlickerSeconds = 0.0f;
+   }
+}
+
+void Sprite_StopFlickering( ActiveSprite_t* sprite )
+{
+   sprite->isFlickering = False;
+   sprite->flickerOff = False;
+}

--- a/DragonQuestino/sprite.h
+++ b/DragonQuestino/sprite.h
@@ -10,6 +10,7 @@
 #define ACTIVE_SPRITE_TEXTURES         8  // two for each direction
 #define ACTIVE_SPRITE_FRAMES           2
 #define ACTIVE_SPRITE_FRAME_SECONDS    0.3f
+#define ACTIVE_SPRITE_FLICKER_SECONDS  0.03f
 
 typedef struct SpriteTexture_t
 {
@@ -31,6 +32,10 @@ typedef struct ActiveSprite_t
    Direction_t direction;
    uint32_t currentFrame;
    float elapsedFrameSeconds;
+
+   Bool_t isFlickering;
+   Bool_t flickerOff;
+   float elapsedFlickerSeconds;
 }
 ActiveSprite_t;
 
@@ -40,6 +45,8 @@ extern "C" {
 
 void Sprite_SetDirection( ActiveSprite_t* sprite, Direction_t direction );
 void Sprite_Tic( ActiveSprite_t* sprite );
+void Sprite_Flicker( ActiveSprite_t* sprite );
+void Sprite_StopFlickering( ActiveSprite_t* sprite );
 
 // game_data.c
 void Sprite_LoadPlayer( ActiveSprite_t* sprite );

--- a/DragonQuestino/tile_map.h
+++ b/DragonQuestino/tile_map.h
@@ -94,6 +94,9 @@
 #define TILEMAP_GOLEM_MAPID                     0
 #define TILEMAP_GOLEM_TILEINDEX                 15063
 
+#define TILEMAP_SWAMP_DAMAGE                    2
+#define TILEMAP_BARRIER_DAMAGE                  15
+
 typedef struct Screen_t Screen_t;
 typedef struct GameFlags_t GameFlags_t;
 typedef struct Player_t Player_t;


### PR DESCRIPTION
## Overview

This reduces the player's HP when walking over swamp and barrier tiles, 2 and 15 points respectively. It also makes the player sprite flicker when walking over these kinds of tiles.

NOTE: I found what I think is a bug with the encounter rates in dungeons, I think we were using the wrong tile index. I haven't tested it though, so if I'm wrong and it was already correct, we might see some weirdness with encounters in dungeons.