### PR TITLE
Bugfix: swamp battles

### DIFF
--- a/DragonQuestino/game_physics.c
+++ b/DragonQuestino/game_physics.c
@@ -414,6 +414,7 @@ internal void Game_ApplyTileDamage( Game_t* game )
       return;
    }
 
+   
    game->screen.needsRedraw = True;
    damage = ( damageRate == 1 ) ? TILEMAP_SWAMP_DAMAGE : TILEMAP_BARRIER_DAMAGE;
    game->player.stats.hitPoints -= Math_Min8u( damage, game->player.stats.hitPoints );

--- a/DragonQuestino/game_physics.c
+++ b/DragonQuestino/game_physics.c
@@ -25,10 +25,18 @@ void Game_TicPhysics( Game_t* game )
    newPos.x = player->sprite.position.x + ( player->velocity.x * CLOCK_FRAME_SECONDS );
    newPos.y = player->sprite.position.y + ( player->velocity.y * CLOCK_FRAME_SECONDS );
 
-   for ( i = 0; i < game->tileMap.activeSpriteCount; i++ )
-   {
-      Game_ClipSprites( &( player->sprite ), &( game->tileMap.activeSprites[i] ), &newPos );
+#if defined( VISUAL_STUDIO_DEV )
+   if ( g_debugFlags.noClip == False ) {
+#endif
+
+      for ( i = 0; i < game->tileMap.activeSpriteCount; i++ )
+      {
+         Game_ClipSprites( &( player->sprite ), &( game->tileMap.activeSprites[i] ), &newPos );
+      }
+
+#if defined( VISUAL_STUDIO_DEV )
    }
+#endif
 
    if ( newPos.x < 0 )
    {

--- a/DragonQuestino/game_render.c
+++ b/DragonQuestino/game_render.c
@@ -96,19 +96,21 @@ void Game_Draw( Game_t* game )
          if ( game->screen.needsRedraw )
          {
             Game_DrawTileMap( game );
-            Game_DrawQuickStatus( game );
-            Game_WipeEnemy( game );
-            Game_DrawEnemy( game );
 
             switch ( game->subState )
             {
                case SubState_Menu:
                   game->activeMenu->hasDrawn = False;
+                  Game_DrawQuickStatus( game );
+                  Game_WipeEnemy( game );
+                  Game_DrawEnemy( game );
                   Menu_Draw( game->activeMenu );
                   Dialog_Draw( &( game->dialog ) );
                   break;
-               case SubState_None:
                case SubState_Dialog:
+                  Game_DrawQuickStatus( game );
+                  Game_WipeEnemy( game );
+                  Game_DrawEnemy( game );
                   Dialog_Draw( &( game->dialog ) );
                   break;
             }


### PR DESCRIPTION
## Overview

I found that getting into a battle while stepping through swamps or barriers either resulted in a crash or some unexpected battle-opening animation. This is because we were trying to re-draw the screen to update the text color after the player takes damage, but wound up in a state where we were either trying to draw a dialog with zero size or wiping/re-drawing the enemy before the checkerboard animation finishes. This should fix all that, but I'm a little concerned our drawing code is getting a little spaghetti-ey.