### PR TITLE
Bugfix: only reset temporary doors when going back to the overworld

### DIFF
--- a/DragonQuestino/game_data.c
+++ b/DragonQuestino/game_data.c
@@ -13951,7 +13951,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
    int32_t i, j;
    uint32_t* tiles32 = (uint32_t*)( tileMap->tiles );
 
-   tileMap->gameFlags->doors = ( 0xFFFF0000 | ( tileMap->gameFlags->doors & 0xFFFF ) );
+   if ( id == TILEMAP_OVERWORLD_ID ) tileMap->gameFlags->doors = ( 0xFFFF0000 | ( tileMap->gameFlags->doors & 0xFFFF ) );
 
    Random_Seed();
 

--- a/DragonQuestinoEditor/DragonQuestinoEditor/FileOps/DataSourceCodeWriter.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/FileOps/DataSourceCodeWriter.cs
@@ -267,7 +267,7 @@ namespace DragonQuestinoEditor.FileOps
          WriteToFileStream( fs, "{\n" );
          WriteToFileStream( fs, "   int32_t i, j;\n" );
          WriteToFileStream( fs, "   uint32_t* tiles32 = (uint32_t*)( tileMap->tiles );\n\n" );
-         WriteToFileStream( fs, "   tileMap->gameFlags->doors = ( 0xFFFF0000 | ( tileMap->gameFlags->doors & 0xFFFF ) );\n\n" );
+         WriteToFileStream( fs, "   if ( id == TILEMAP_OVERWORLD_ID ) tileMap->gameFlags->doors = ( 0xFFFF0000 | ( tileMap->gameFlags->doors & 0xFFFF ) );\n\n" );
          WriteToFileStream( fs, "   Random_Seed();\n\n" );
          WriteToFileStream( fs, "   switch( id )\n" );
          WriteToFileStream( fs, "   {\n" );


### PR DESCRIPTION
## Overview

I figured temporary doors should stay open as long as you're within the general area, which means they should only be reset when you exit back into the overworld.