### PR TITLE
Bugfix: enemy flee animations and dialogs

### DIFF
--- a/DragonQuestino/battle.c
+++ b/DragonQuestino/battle.c
@@ -1056,6 +1056,8 @@ internal void Battle_EnemyCastSleepAnimation( Battle_t* battle )
    Battle_MultiPauseBeforeAnimation( battle, 1, AnimationId_Pause, Battle_EnemyTurn );
 }
 
+// MUFFINS: if the enemy runs away immediately, we should use a different function.
+// also though, the fade animation isn't working here, WHY???
 internal void Battle_EnemyFlee( Battle_t* battle )
 {
    char msg[64];

--- a/DragonQuestino/battle.c
+++ b/DragonQuestino/battle.c
@@ -61,6 +61,7 @@ internal void Battle_EnemyCastSleepMessageCallback( Battle_t* battle );
 internal void Battle_EnemyCastSleepAnimation( Battle_t* battle );
 internal void Battle_EnemyFlee( Battle_t* battle );
 internal void Battle_EnemyFleeCallback( Battle_t* battle );
+internal void Battle_EnemyFledCallback( Battle_t* battle );
 internal void Battle_MultiPauseBeforeAnimation( Battle_t* battle, uint32_t numPauses,
                                                 AnimationId_t finalAnimationId, void ( *callback )( Battle_t* ) );
 internal void Battle_DefeatedWizardDragonlordPauseCallback( Battle_t* battle );
@@ -1056,8 +1057,6 @@ internal void Battle_EnemyCastSleepAnimation( Battle_t* battle )
    Battle_MultiPauseBeforeAnimation( battle, 1, AnimationId_Pause, Battle_EnemyTurn );
 }
 
-// MUFFINS: if the enemy runs away immediately, we should use a different function.
-// also though, the fade animation isn't working here, WHY???
 internal void Battle_EnemyFlee( Battle_t* battle )
 {
    char msg[64];
@@ -1070,11 +1069,15 @@ internal void Battle_EnemyFlee( Battle_t* battle )
 
 internal void Battle_EnemyFleeCallback( Battle_t* battle )
 {
-   battle->isOver = True;
    AnimationChain_Reset( &( battle->game->animationChain ) );
    AnimationChain_PushAnimation( &( battle->game->animationChain ), AnimationId_Pause );
-   AnimationChain_PushAnimation( &( battle->game->animationChain ), AnimationId_Battle_EnemyFadeOut );
+   AnimationChain_PushAnimationWithCallback( &( battle->game->animationChain ), AnimationId_Battle_EnemyFadeOut, Battle_EnemyFledCallback, battle );
    AnimationChain_Start( &( battle->game->animationChain ) );
+}
+
+internal void Battle_EnemyFledCallback( Battle_t* battle )
+{
+   battle->isOver = True;
 }
 
 internal void Battle_MultiPauseBeforeAnimation( Battle_t* battle, uint32_t numPauses,

--- a/DragonQuestino/battle.c
+++ b/DragonQuestino/battle.c
@@ -413,8 +413,8 @@ internal void Battle_EnemyDefeatedMessageCallback( Battle_t* battle )
    else
    {
       Dialog_PushSection( dialog, msg );
-      Math_CollectAmount16u( &( battle->experienceGained ), enemy->experience );
-      Math_CollectAmount16u( &( battle->goldGained ), enemy->gold );
+      battle->experienceGained = Math_CollectAmount16u( &( player->experience ), enemy->experience );
+      battle->goldGained = Math_CollectAmount16u( &( player->gold ), enemy->gold );
       battle->newLevel = Player_GetLevelFromExperience( player );
       battle->previousSpells = player->spells;
 

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -398,7 +398,7 @@ internal void Game_BattleIntroMessageCallback( Game_t* game )
          sprintf( msg, STRING_BATTLE_ENEMYAPPROACHES, enemyName );
          Dialog_PushSectionWithCallback( &( game->dialog ), msg, Battle_EnemyInitiativeFlee, &( game->battle ) );
       }
-      if ( game->battle.turn == BattleTurn_Player )
+      else if ( game->battle.turn == BattleTurn_Player )
       {
          sprintf( msg, STRING_BATTLE_ENEMYAPPROACHESINITIATIVE, enemyName );
          Dialog_PushSectionWithCallback( &( game->dialog ), msg, Game_ResetBattleMenu, game );


### PR DESCRIPTION
## Overview

This fixes two bugs with enemy flee animations:

- If an enemy flees instantly, it should fade out (this wasn't working because I was prematurely setting `battle->isOver` to true).
- When an enemy flees, it should fade out (this wasn't working because there was an `if` where there should've been an `else if`).

BONUS: This also fixes a bug where you could collect more than the max amount of experience and gold, which caused an overflow.