### PR TITLE
Bugfix: show the main battle menu behind the spell and item sub-menus

### DIFF
--- a/DragonQuestino/game_render.c
+++ b/DragonQuestino/game_render.c
@@ -120,6 +120,13 @@ void Game_Draw( Game_t* game )
                Game_DrawQuickStatus( game );
                Game_WipeEnemy( game );
                Game_DrawEnemy( game );
+               switch ( game->activeMenu->id )
+               {
+                  case MenuId_BattleSpell:
+                  case MenuId_BattleItem:
+                     Menu_Draw( &( game->menus[MenuId_Battle] ) );
+                     break;
+               }
                Menu_Draw( game->activeMenu );
                Dialog_Draw( &( game->dialog ) );
                break;


### PR DESCRIPTION
## Overview

This is an artifact from when we changed the rendering system, we're supposed to be showing the main battle menu behind the spell and item sub-menus.