### PR TITLE
Added armor healing effects

### DIFF
--- a/DragonQuestino/game_physics.c
+++ b/DragonQuestino/game_physics.c
@@ -208,6 +208,11 @@ void Game_PlayerSteppedOnTile( Game_t* game )
       // must have stepped on a damage tile and died
       return;
    }
+   
+   if ( game->player.armor.id == ARMOR_MAGICARMOR_ID || game->player.armor.id == ARMOR_ERDRICKSARMOR_ID )
+   {
+      Player_RestoreHitPoints( &( game->player ), 1 );
+   }
 
    game->player.maxVelocity = TileMap_GetWalkSpeedForTileIndex( &( game->tileMap ), game->player.tileIndex );
    portal = TileMap_GetPortalForTileIndex( &( game->tileMap ), game->player.tileIndex );


### PR DESCRIPTION
## Overview

This makes sure the player recovers 1 HP on every step, unless they die from swamp/barrier damage before that can happen.