### PR TITLE
Allow going back from password and name entry

### DIFF
--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -234,6 +234,12 @@ void Game_ChangeToOverworldState( Game_t* game )
    game->overworldInactivitySeconds = 0.0f;
 }
 
+void Game_ChangeToStartupState( Game_t* game )
+{
+   game->mainState = MainState_Startup;
+   Screen_WipeColor( &( game->screen ), COLOR_BLACK );
+}
+
 void Game_ChangeToEnterNameState( Game_t* game )
 {
    game->mainState = MainState_EnterName;
@@ -248,14 +254,14 @@ void Game_ChangeToEnterPasswordState( Game_t* game )
    // MUFFINS: this gives us some goodies for testing
    //Game_Load( game, "..91Mf....9Q0RP-E4iyABHdtPf..4" ); // level 21 with some good stuff (haven't saved Princess)
    //Game_Load( game, "APD...9..39I.b.-....5wqJ2p...4" ); // level 30 with everything (haven't saved Princess)
-   Game_Load( game, "..8AAP....8AAAAAAADg4Fq2rYf..4" ); // WRATH
-   Game_ChangeToOverworldState( game );
+   //Game_Load( game, "..8AAP....8AAAAAAADg4Fq2rYf..4" ); // WRATH
+   //Game_ChangeToOverworldState( game );
 
-   /*game->mainState = MainState_EnterPassword;
+   game->mainState = MainState_EnterPassword;
    game->alphaPicker.position.x = 28;
    game->alphaPicker.position.y = 28;
    Screen_WipeColor( &( game->screen ), COLOR_BLACK );
-   AlphaPicker_Reset( &( game->alphaPicker ), STRING_ALPHAPICKER_PASSWORD_TITLE, True );*/
+   AlphaPicker_Reset( &( game->alphaPicker ), STRING_ALPHAPICKER_PASSWORD_TITLE, True );
 }
 
 void Game_ChangeToBattleState( Game_t* game )

--- a/DragonQuestino/game.h
+++ b/DragonQuestino/game.h
@@ -67,6 +67,7 @@ void Game_Init( Game_t* game, uint16_t* screenBuffer );
 void Game_Load( Game_t* game, const char* password );
 void Game_Reset( Game_t* game );
 void Game_Tic( Game_t* game );
+void Game_ChangeToStartupState( Game_t* game );
 void Game_ChangeToEnterNameState( Game_t* game );
 void Game_ChangeToEnterPasswordState( Game_t* game );
 void Game_ChangeToOverworldState( Game_t* game );

--- a/DragonQuestino/game_input.c
+++ b/DragonQuestino/game_input.c
@@ -469,6 +469,10 @@ internal void Game_HandleEnterNameInput( Game_t* game )
       {
          name[length - 1] = 0;
       }
+      else
+      {
+         Game_ChangeToStartupState( game );
+      }
    }
    else
    {
@@ -509,6 +513,10 @@ internal void Game_HandleEnterPasswordInput( Game_t* game )
       if ( length > 0 )
       {
          password[length - 1] = 0;
+      }
+      else
+      {
+         Game_ChangeToStartupState( game );
       }
    }
    else


### PR DESCRIPTION
## Overview

If you press B on either the name entry or password entry screens (and no letters have been entered), it should go back to the title menu.