### PR TITLE
Adjust the player's low-health red text

### DIFF
--- a/DragonQuestino/player.h
+++ b/DragonQuestino/player.h
@@ -7,7 +7,7 @@
 
 typedef struct TileMap_t TileMap_t;
 
-#define PLAYER_LOWHEALTH_PERCENTAGE             0.2f
+#define PLAYER_LOWHEALTH_PERCENTAGE             0.26f
 
 #define SPELL_HAS_HEAL( x )                     ( ( x ) & 0x1 )
 #define SPELL_HAS_SIZZ( x )                     ( ( x ) & 0x2 )


### PR DESCRIPTION
## Overview

Based on testing in the original game, I think the threshold is 30%, but I feel like it should be lower if you're at a higher level, so I set it to 26%. Either way, it should be higher than 20%.