### PR TITLE
Remove cursed flag from passwords

### DIFF
--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -259,8 +259,7 @@ void Game_ChangeToEnterNameState( Game_t* game )
 void Game_ChangeToEnterPasswordState( Game_t* game )
 {
    // MUFFINS: this gives us some goodies for testing
-   //Game_Load( game, "pgT...-gIwBZ...-...fExHdtPf..5" ); // level 30 with everything, but no rainbow bridge
-   Game_Load( game, "ef8AAH....-AAAAAAAAA4P.......x" ); // cursed belt
+   Game_Load( game, "pgT...-gIwBZ...-...fExHdtPf..5" ); // level 30 with everything, but no rainbow bridge
    Game_ChangeToOverworldState( game );
    
    /*game->mainState = MainState_EnterPassword;

--- a/DragonQuestino/game_password.c
+++ b/DragonQuestino/game_password.c
@@ -22,7 +22,7 @@ void Game_GetPassword( Game_t* game, char* password )
 
       ( player->items << 7 ) |                                    // items (25 bits)
       ( (uint32_t)( player->townsVisited ) << 1 ) |               // towns visited (6 bits)
-      ( player->isCursed ? 0x1 : 0x0 ),                           // is cursed (1 bit)
+      0x1,                                                        // reserved (1 bit)
 
       ( (uint32_t)( player->gold ) << 16 ) |                      // gold (16 bits)
       ( ( player->weapon.id & 0x7 ) << 13 ) |                     // weapon (3 bits)
@@ -141,7 +141,6 @@ Bool_t Game_LoadFromPassword( Game_t* game, const char* password )
    player->gold = (uint16_t)( encodedBits[3] >> 16 );
    player->items = ( encodedBits[2] >> 7 ) & 0x1FFFFFF;
    player->townsVisited = (uint8_t)( ( encodedBits[2] >> 1 ) & 0x3F );
-   player->isCursed = (Bool_t)( encodedBits[2] & 0x1 );
 
    player->level = Player_GetLevelFromExperience( player->experience );
    Player_UpdateSpellsToLevel( player, player->level );

--- a/DragonQuestinoPasswordGenerator/DragonQuestinoPasswordGenerator/MainWindow.xaml
+++ b/DragonQuestinoPasswordGenerator/DragonQuestinoPasswordGenerator/MainWindow.xaml
@@ -80,8 +80,6 @@
                             DisplayMemberPath="DisplayText"
                             SelectedValue="{Binding SelectedShield}" />
                </StackPanel>
-               <CheckBox Content="Cursed"
-                         IsChecked="{Binding PlayerIsCursed, Mode=TwoWay}" />
             </StackPanel>
          </GroupBox>
          

--- a/DragonQuestinoPasswordGenerator/DragonQuestinoPasswordGenerator/ViewModels/MainWindowViewModel.cs
+++ b/DragonQuestinoPasswordGenerator/DragonQuestinoPasswordGenerator/ViewModels/MainWindowViewModel.cs
@@ -160,19 +160,6 @@ namespace DragonQuestinoPasswordGenerator.ViewModels
          }
       }
 
-      private bool _playerIsCursed = false;
-      public bool PlayerIsCursed
-      {
-         get => _playerIsCursed;
-         set
-         {
-            if ( SetProperty( ref _playerIsCursed, value ) )
-            {
-               UpdatePassword();
-            }
-         }
-      }
-
       private bool _visitedTantegel = false;
       public bool VisitedTantegel
       {
@@ -1098,8 +1085,8 @@ namespace DragonQuestinoPasswordGenerator.ViewModels
 
          // 25 bits: player's items
          // 6 bits: towns visited
-         // 1 bit: player is cursed
-         encodedBits[2] = ( itemFlags << 7 ) | ( townVisitedFlags << 1 ) | ( _playerIsCursed ? (UInt32)0x1 : 0 );
+         // 1 bit: reserved
+         encodedBits[2] = ( itemFlags << 7 ) | ( townVisitedFlags << 1 ) | (UInt32)0x1;
 
          // 16 bits: gold
          // 3 bits: weapon
@@ -1274,7 +1261,6 @@ namespace DragonQuestinoPasswordGenerator.ViewModels
          SetTreasuresCollectedFromFlags( encodedBits[1] );
          SetItemsFromFlags( ( encodedBits[2] >> 7 ) & 0x1FFFFFF );
          SetTownsVisitedFromFlags( ( encodedBits[2] >> 1 ) & 0x3F );
-         PlayerIsCursed = ( encodedBits[2] & 0x1 ) != 0;
          PlayerGold = ( encodedBits[3] >> 16 ).ToString();
          SetSpecialEnemiesDefeatedFromFlags( ( encodedBits[3] >> 5 ) & 0x7 );
          RescuedGwaelin = ( ( encodedBits[3] >> 4 ) & 0x1 ) != 0;


### PR DESCRIPTION
## Overview

Technically you shouldn't be able to get a password if you're cursed, so there's no reason to encode it into the password. Maybe we can use the extra bit somehow for the checksum, or some other thing we haven't expected.