### PR TITLE
Bugfix: NPC positions

### DIFF
--- a/DragonQuestinoEditor/DragonQuestinoEditor/FileOps/DataSourceCodeWriter.cs
+++ b/DragonQuestinoEditor/DragonQuestinoEditor/FileOps/DataSourceCodeWriter.cs
@@ -338,8 +338,9 @@ namespace DragonQuestinoEditor.FileOps
                for ( int i = 0; i < tileMap.NonPlayerCharacters.Count; i++ )
                {
                   var npc = tileMap.NonPlayerCharacters[i];
-                  int xPos = ( npc.TileIndex % tileMap.TilesX ) * Constants.SpriteFrameSize;
-                  int yPos = ( npc.TileIndex / tileMap.TilesX ) * Constants.SpriteFrameSize;
+                  int canonicalTileIndex = npc.TileIndex + ( ( npc.TileIndex / tileMap.TilesX ) * ( Constants.TileMapMaxTilesX - tileMap.TilesX ) );
+                  int xPos = ( canonicalTileIndex % Constants.TileMapMaxTilesX ) * Constants.SpriteFrameSize;
+                  int yPos = ( canonicalTileIndex / Constants.TileMapMaxTilesX ) * Constants.SpriteFrameSize;
 
                   WriteToFileStream( fs, string.Format( "         tileMap->npcs[{0}].id = {1};\n", i, npc.Id ) );
                   WriteToFileStream( fs, string.Format( "         tileMap->npcs[{0}].tileIndex = {1};\n", i, npc.TileIndex ) );


### PR DESCRIPTION
Addresses card: #149 

## Overview

Sometimes NPCs show up in weird places. I'm honestly still not sure how this happened, and it's possible that it's not actually fixed, but this bit of code was all wrong. We weren't placing them in the correct position originally, so I guess it's possible that some of them got loaded in at the wrong spot before we corrected their positions? I don't know, I just know I can't seem to repro this anymore, so I'm closing it for now.