### PR TITLE
Start button should finish text entry

### DIFF
--- a/DragonQuestino/enums.h
+++ b/DragonQuestino/enums.h
@@ -11,6 +11,7 @@ typedef enum Button_t
    Button_Down,
    Button_A,
    Button_B,
+   Button_Start,
 
    Button_Count
 }

--- a/DragonQuestino/game_input.c
+++ b/DragonQuestino/game_input.c
@@ -451,6 +451,13 @@ internal void Game_HandleEnterNameInput( Game_t* game )
    char* name = game->player.name;
    size_t length = strlen( name );
 
+   if ( game->input.buttonStates[Button_Start].pressed )
+   {
+      if ( length > 0 )
+      {
+         Game_Load( game, "" );
+      }
+   }
    if ( game->input.buttonStates[Button_A].pressed )
    {
       if ( game->alphaPicker.selectedIndex == 64 )
@@ -496,6 +503,13 @@ internal void Game_HandleEnterPasswordInput( Game_t* game )
    char* password = game->password;
    size_t length = strlen( password );
 
+   if ( game->input.buttonStates[Button_Start].pressed )
+   {
+      if ( length == PASSWORD_LENGTH )
+      {
+         Game_Load( game, password );
+      }
+   }
    if ( game->input.buttonStates[Button_A].pressed )
    {
       if ( game->alphaPicker.selectedIndex == 64 )

--- a/DragonQuestino/input.c
+++ b/DragonQuestino/input.c
@@ -28,6 +28,7 @@ void Input_Read( Input_t* input )
    Input_UpdateButtonState( &( input->buttonStates[ Button_Up ] ), ( nesInput & INPUT_UP_FLAG ) ? True : False );
    Input_UpdateButtonState( &( input->buttonStates[ Button_Right ] ), ( nesInput & INPUT_RIGHT_FLAG ) ? True : False );
    Input_UpdateButtonState( &( input->buttonStates[ Button_Down ] ), ( nesInput & INPUT_DOWN_FLAG ) ? True : False );
+   Input_UpdateButtonState( &( input->buttonStates[ Button_Start ] ), ( nesInput & INPUT_START_FLAG ) ? True : False );
 #endif
 }
 

--- a/DragonQuestinoWinDev/DragonQuestinoWinDev/win_main.c
+++ b/DragonQuestinoWinDev/DragonQuestinoWinDev/win_main.c
@@ -186,6 +186,7 @@ internal void InitButtonMap()
    g_globals.buttonMap[Button_Down] = VK_DOWN;
    g_globals.buttonMap[Button_A] = 0x58; // X
    g_globals.buttonMap[Button_B] = 0x5A; // Z
+   g_globals.buttonMap[Button_Start] = VK_RETURN;
 }
 
 internal void HandleKeyboardInput( uint32_t keyCode, LPARAM flags )


### PR DESCRIPTION
## Overview

This is just a quality-of-life update, now that we have a "start" button, we should at least make use of it. If you're entering your name or entering a password at the start of the game, the start button is the same as the "end" button.