### PR TITLE
Determine stat growth based on the player's name

### DIFF
--- a/DragonQuestino/battle.c
+++ b/DragonQuestino/battle.c
@@ -445,10 +445,10 @@ internal void Battle_EnemyDefeatedMessageCallback( Battle_t* battle )
       {
          Dialog_PushSectionWithCallback( dialog, STRING_BATTLE_LEVELUP, Battle_NewLevelCallback, battle );
 
-         battle->strengthGained = g_strengthTable[battle->newLevel] - player->stats.strength;
-         battle->agilityGained = g_agilityTable[battle->newLevel] - player->stats.agility;
-         battle->hitPointsGained = g_hitPointsTable[battle->newLevel] - player->stats.maxHitPoints;
-         battle->magicPointsGained = g_magicPointsTable[battle->newLevel] - player->stats.maxMagicPoints;
+         battle->strengthGained = Player_GetStrengthFromLevel( player, battle->newLevel ) - player->stats.strength;
+         battle->agilityGained = Player_GetAgilityFromLevel( player, battle->newLevel ) - player->stats.agility;
+         battle->hitPointsGained = Player_GetMaxHitPointsFromLevel( player, battle->newLevel ) - player->stats.maxHitPoints;
+         battle->magicPointsGained = Player_GetMaxMagicPointsFromLevel( player, battle->newLevel ) - player->stats.maxMagicPoints;
          Player_UpdateSpellsToLevel( &( battle->game->player ), battle->newLevel );
 
          player->stats.strength += battle->strengthGained;

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -83,12 +83,12 @@ void Game_Reset( Game_t* game )
    player->stats.stopSpellResist = 0;
    player->stats.hurtResist = 0;
    player->stats.dodge = 1;
-   player->stats.strength = g_strengthTable[0];
-   player->stats.agility = g_agilityTable[0];
-   player->stats.hitPoints = g_hitPointsTable[0];
-   player->stats.maxHitPoints = g_hitPointsTable[0];
-   player->stats.magicPoints = g_magicPointsTable[0];
-   player->stats.maxMagicPoints = g_magicPointsTable[0];
+   player->stats.strength = Player_GetStrengthFromLevel( player, 0 );
+   player->stats.agility = Player_GetAgilityFromLevel( player, 0 );
+   player->stats.maxHitPoints = Player_GetMaxHitPointsFromLevel( player, 0 );
+   player->stats.hitPoints = player->stats.maxHitPoints;
+   player->stats.maxMagicPoints = Player_GetMaxMagicPointsFromLevel( player, 0 );
+   player->stats.magicPoints = player->stats.maxMagicPoints;
    player->isCursed = False;
 
    Player_LoadWeapon( player, WEAPON_NONE_ID );

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -83,12 +83,6 @@ void Game_Reset( Game_t* game )
    player->stats.stopSpellResist = 0;
    player->stats.hurtResist = 0;
    player->stats.dodge = 1;
-   player->stats.strength = Player_GetStrengthFromLevel( player, 0 );
-   player->stats.agility = Player_GetAgilityFromLevel( player, 0 );
-   player->stats.maxHitPoints = Player_GetMaxHitPointsFromLevel( player, 0 );
-   player->stats.hitPoints = player->stats.maxHitPoints;
-   player->stats.maxMagicPoints = Player_GetMaxMagicPointsFromLevel( player, 0 );
-   player->stats.magicPoints = player->stats.maxMagicPoints;
    player->isCursed = False;
 
    Player_LoadWeapon( player, WEAPON_NONE_ID );
@@ -100,6 +94,8 @@ void Game_Reset( Game_t* game )
 
 void Game_Load( Game_t* game, const char* password )
 {
+   Player_t* player = &( game->player );
+
    if ( strlen( password ) > 0 )
    {
       if ( Game_LoadFromPassword( game, password ) )
@@ -125,9 +121,16 @@ void Game_Load( Game_t* game, const char* password )
       game->subState = SubState_None;
    }
 
+   player->stats.strength = Player_GetStrengthFromLevel( player, 0 );
+   player->stats.agility = Player_GetAgilityFromLevel( player, 0 );
+   player->stats.maxHitPoints = Player_GetMaxHitPointsFromLevel( player, 0 );
+   player->stats.hitPoints = player->stats.maxHitPoints;
+   player->stats.maxMagicPoints = Player_GetMaxMagicPointsFromLevel( player, 0 );
+   player->stats.magicPoints = player->stats.maxMagicPoints;
+
    TileMap_Load( &( game->tileMap ), TILEMAP_TANTEGEL_THRONEROOM_ID );
-   game->player.tileIndex = 128; // in front of King Lorik
-   Player_SetCanonicalTileIndex( &( game->player ) );
+   player->tileIndex = 128; // in front of King Lorik
+   Player_SetCanonicalTileIndex( player );
 }
 
 void Game_Tic( Game_t* game )

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -64,7 +64,7 @@ void Game_Reset( Game_t* game )
    game->targetPortal = 0;
    game->overworldInactivitySeconds = 0.0f;
 
-   player->name[0] = 0;
+   Player_SetName( player, "" );
    player->sprite.position.x = (float)( TILE_SIZE * 8 ) + 2.0f;
    player->sprite.position.y = (float)( TILE_SIZE * 6 ) + 4.0f;
    player->sprite.direction = Direction_Up;

--- a/DragonQuestino/game_input.c
+++ b/DragonQuestino/game_input.c
@@ -448,8 +448,10 @@ internal void Game_OpenBattleItemMenu( Game_t* game )
 internal void Game_HandleEnterNameInput( Game_t* game )
 {
    uint32_t i;
-   char* name = game->player.name;
-   size_t length = strlen( name );
+   char name[9];
+   size_t length = strlen( game->player.name );
+
+   strcpy( name, game->player.name );
 
    if ( game->input.buttonStates[Button_Start].pressed )
    {
@@ -469,8 +471,9 @@ internal void Game_HandleEnterNameInput( Game_t* game )
       }
       else if ( length < 8 )
       {
-         game->player.name[length] = AlphaPicker_GetSelectedChar( &( game->alphaPicker ) );
-         game->player.name[length + 1] = 0;
+         name[length] = AlphaPicker_GetSelectedChar( &( game->alphaPicker ) );
+         name[length + 1] = 0;
+         Player_SetName( &( game->player ), name );
          AlphaPicker_ResetCarat( &( game->alphaPicker ) );
       }
    }
@@ -479,6 +482,7 @@ internal void Game_HandleEnterNameInput( Game_t* game )
       if ( length > 0 )
       {
          name[length - 1] = 0;
+         Player_SetName( &( game->player ), name );
       }
       else
       {

--- a/DragonQuestino/game_password.c
+++ b/DragonQuestino/game_password.c
@@ -167,7 +167,7 @@ internal void Password_InjectPlayerName( Player_t* player, uint32_t* encodedBits
    if ( length <= 0 )
    {
       length = 1;
-      player->name[0] = ' ';
+      Player_SetName( player, " " );
    }
 
    for ( i = 0; i < 8; i++ )
@@ -216,7 +216,7 @@ internal void Password_InjectChecksum( uint32_t* encodedBits )
 internal void Password_ExtractPlayerName( Player_t* player, uint32_t* encodedBits )
 {
    uint32_t length, i;
-   char* name = player->name;
+   char name[9];
 
    name[0] = 0;
    length = ( ( encodedBits[5] >> 13 ) & 0x7 ) + 1;
@@ -270,6 +270,8 @@ internal void Password_ExtractPlayerName( Player_t* player, uint32_t* encodedBit
          name[i] = ' ';
       }
    }
+
+   Player_SetName( player, name );
 }
 
 internal char Password_GetCharFromBits( uint32_t bits )

--- a/DragonQuestino/game_password.c
+++ b/DragonQuestino/game_password.c
@@ -145,12 +145,12 @@ Bool_t Game_LoadFromPassword( Game_t* game, const char* password )
    player->level = Player_GetLevelFromExperience( player->experience );
    Player_UpdateSpellsToLevel( player, player->level );
 
-   player->stats.strength = g_strengthTable[player->level];
-   player->stats.agility = g_agilityTable[player->level];
-   player->stats.hitPoints = g_hitPointsTable[player->level];
-   player->stats.maxHitPoints = g_hitPointsTable[player->level];
-   player->stats.magicPoints = g_magicPointsTable[player->level];
-   player->stats.maxMagicPoints = g_magicPointsTable[player->level];
+   player->stats.strength = Player_GetStrengthFromLevel( player, player->level );
+   player->stats.agility = Player_GetAgilityFromLevel( player, player->level );
+   player->stats.maxHitPoints = Player_GetMaxHitPointsFromLevel( player, player->level );
+   player->stats.hitPoints = player->stats.maxHitPoints;
+   player->stats.maxMagicPoints = Player_GetMaxMagicPointsFromLevel( player, player->level );
+   player->stats.magicPoints = player->stats.maxMagicPoints;
 
    Player_LoadWeapon( player, ( encodedBits[3] >> 13 ) & 0x7 );
    Player_LoadArmor( player, ( encodedBits[3] >> 10 ) & 0x7 );

--- a/DragonQuestino/player.c
+++ b/DragonQuestino/player.c
@@ -15,6 +15,20 @@ void Player_Init( Player_t* player, TileMap_t* tileMap )
    Sprite_LoadActive( &( player->sprite ), ACTIVE_SPRITE_PLAYER_ID );
 }
 
+void Player_SetName( Player_t* player, const char* name )
+{
+   uint32_t i, nameSum = 0;
+
+   strcpy( player->name, name );
+
+   for ( i = 0; i < strlen( player->name ); i++ )
+   {
+      nameSum += (uint32_t)( player->name[i] ) % 16;
+   }
+
+   player->statGrowthType = nameSum % 4;
+}
+
 uint8_t Player_GetLevelFromExperience( uint16_t experience )
 {
    uint8_t i;

--- a/DragonQuestino/player.c
+++ b/DragonQuestino/player.c
@@ -67,7 +67,9 @@ uint8_t Player_GetMaxHitPointsFromLevel( Player_t* player, uint8_t level )
 
 uint8_t Player_GetMaxMagicPointsFromLevel( Player_t* player, uint8_t level )
 {
-   return Player_GetStatFromLevel( player, level, g_magicPointsTable, ( player->statGrowthType == 1 || player->statGrowthType == 3 ) ? True : False );
+   return ( player->spells == 0 )
+      ? 0
+      : Player_GetStatFromLevel( player, level, g_magicPointsTable, ( player->statGrowthType == 1 || player->statGrowthType == 3 ) ? True : False );
 }
 
 uint16_t Player_GetExperienceRemaining( Player_t* player )

--- a/DragonQuestino/player.c
+++ b/DragonQuestino/player.c
@@ -30,6 +30,38 @@ uint8_t Player_GetLevelFromExperience( uint16_t experience )
    return i;
 }
 
+uint8_t Player_GetStrengthFromLevel( Player_t* player, uint8_t level )
+{
+   // TODO
+   UNUSED_PARAM( player );
+
+   return g_strengthTable[level];
+}
+
+uint8_t Player_GetAgilityFromLevel( Player_t* player, uint8_t level )
+{
+   // TODO
+   UNUSED_PARAM( player );
+
+   return g_agilityTable[level];
+}
+
+uint8_t Player_GetMaxHitPointsFromLevel( Player_t* player, uint8_t level )
+{
+   // TODO
+   UNUSED_PARAM( player );
+
+   return g_hitPointsTable[level];
+}
+
+uint8_t Player_GetMaxMagicPointsFromLevel( Player_t* player, uint8_t level )
+{
+   // TODO
+   UNUSED_PARAM( player );
+
+   return g_magicPointsTable[level];
+}
+
 uint16_t Player_GetExperienceRemaining( Player_t* player )
 {
    return ( player->level == ( STAT_TABLE_SIZE - 1 ) ) ? 0 : ( g_experienceTable[player->level + 1] - player->experience );

--- a/DragonQuestino/player.c
+++ b/DragonQuestino/player.c
@@ -4,6 +4,8 @@
 #include "math.h"
 #include "tables.h"
 
+internal uint32_t Player_GetNameSum( Player_t* player );
+
 void Player_Init( Player_t* player, TileMap_t* tileMap )
 {
    player->tileMap = tileMap;
@@ -17,16 +19,8 @@ void Player_Init( Player_t* player, TileMap_t* tileMap )
 
 void Player_SetName( Player_t* player, const char* name )
 {
-   uint32_t i, nameSum = 0;
-
    strcpy( player->name, name );
-
-   for ( i = 0; i < strlen( player->name ); i++ )
-   {
-      nameSum += (uint32_t)( player->name[i] ) % 16;
-   }
-
-   player->statGrowthType = nameSum % 4;
+   player->statGrowthType = Player_GetNameSum( player ) % 4;
 }
 
 uint8_t Player_GetLevelFromExperience( uint16_t experience )
@@ -44,36 +38,36 @@ uint8_t Player_GetLevelFromExperience( uint16_t experience )
    return i;
 }
 
+internal uint8_t Player_GetStatFromLevel( Player_t* player, uint8_t level, uint8_t* table, Bool_t shortTerm )
+{
+   uint8_t stat = table[level];
+
+   if ( shortTerm )
+   {
+      stat = ( ( Player_GetNameSum( player ) / 4 ) % 4 ) + ( ( stat * 9 ) / 10 );
+   }
+
+   return stat;
+}
+
 uint8_t Player_GetStrengthFromLevel( Player_t* player, uint8_t level )
 {
-   // TODO
-   UNUSED_PARAM( player );
-
-   return g_strengthTable[level];
+   return Player_GetStatFromLevel( player, level, g_strengthTable, ( player->statGrowthType == 0 || player->statGrowthType == 2 ) ? True : False );
 }
 
 uint8_t Player_GetAgilityFromLevel( Player_t* player, uint8_t level )
 {
-   // TODO
-   UNUSED_PARAM( player );
-
-   return g_agilityTable[level];
+   return Player_GetStatFromLevel( player, level, g_strengthTable, ( player->statGrowthType == 0 || player->statGrowthType == 1 ) ? True : False );
 }
 
 uint8_t Player_GetMaxHitPointsFromLevel( Player_t* player, uint8_t level )
 {
-   // TODO
-   UNUSED_PARAM( player );
-
-   return g_hitPointsTable[level];
+   return Player_GetStatFromLevel( player, level, g_strengthTable, ( player->statGrowthType == 2 || player->statGrowthType == 3 ) ? True : False );
 }
 
 uint8_t Player_GetMaxMagicPointsFromLevel( Player_t* player, uint8_t level )
 {
-   // TODO
-   UNUSED_PARAM( player );
-
-   return g_magicPointsTable[level];
+   return Player_GetStatFromLevel( player, level, g_strengthTable, ( player->statGrowthType == 1 || player->statGrowthType == 3 ) ? True : False );
 }
 
 uint16_t Player_GetExperienceRemaining( Player_t* player )
@@ -258,4 +252,16 @@ void Player_CenterOnTile( Player_t* player )
 
    player->sprite.position.x = (float)( tileX + ( ( TILE_SIZE / 2 ) - ( player->sprite.hitBoxSize.x / 2 ) ) );
    player->sprite.position.y = (float)( tileY + ( ( TILE_SIZE / 2 ) - ( player->sprite.hitBoxSize.y / 2 ) ) );
+}
+
+internal uint32_t Player_GetNameSum( Player_t* player )
+{
+   uint32_t i, nameSum = 0;
+
+   for ( i = 0; i < strlen( player->name ); i++ )
+   {
+      nameSum += (uint32_t)( player->name[i] ) % 16;
+   }
+
+   return nameSum;
 }

--- a/DragonQuestino/player.c
+++ b/DragonQuestino/player.c
@@ -57,17 +57,17 @@ uint8_t Player_GetStrengthFromLevel( Player_t* player, uint8_t level )
 
 uint8_t Player_GetAgilityFromLevel( Player_t* player, uint8_t level )
 {
-   return Player_GetStatFromLevel( player, level, g_strengthTable, ( player->statGrowthType == 0 || player->statGrowthType == 1 ) ? True : False );
+   return Player_GetStatFromLevel( player, level, g_agilityTable, ( player->statGrowthType == 0 || player->statGrowthType == 1 ) ? True : False );
 }
 
 uint8_t Player_GetMaxHitPointsFromLevel( Player_t* player, uint8_t level )
 {
-   return Player_GetStatFromLevel( player, level, g_strengthTable, ( player->statGrowthType == 2 || player->statGrowthType == 3 ) ? True : False );
+   return Player_GetStatFromLevel( player, level, g_hitPointsTable, ( player->statGrowthType == 2 || player->statGrowthType == 3 ) ? True : False );
 }
 
 uint8_t Player_GetMaxMagicPointsFromLevel( Player_t* player, uint8_t level )
 {
-   return Player_GetStatFromLevel( player, level, g_strengthTable, ( player->statGrowthType == 1 || player->statGrowthType == 3 ) ? True : False );
+   return Player_GetStatFromLevel( player, level, g_magicPointsTable, ( player->statGrowthType == 1 || player->statGrowthType == 3 ) ? True : False );
 }
 
 uint16_t Player_GetExperienceRemaining( Player_t* player )

--- a/DragonQuestino/player.h
+++ b/DragonQuestino/player.h
@@ -208,13 +208,18 @@ typedef struct Player_t
    uint32_t holyProtectionSteps;
    char name[9];
    BattleStats_t stats;
-   uint32_t statGrowthType;
    Accessory_t weapon;
    Accessory_t armor;
    Accessory_t shield;
    uint8_t level;
    uint16_t experience;
    uint16_t gold;
+
+   // 0: short term strength and agility
+   // 1: short term agility and MP
+   // 2: short term strength and HP
+   // 3: short term HP and MP
+   uint32_t statGrowthType;
 
    // bits 0-2: keys
    // bits 3-5: herbs

--- a/DragonQuestino/player.h
+++ b/DragonQuestino/player.h
@@ -208,6 +208,7 @@ typedef struct Player_t
    uint32_t holyProtectionSteps;
    char name[9];
    BattleStats_t stats;
+   uint32_t statGrowthType;
    Accessory_t weapon;
    Accessory_t armor;
    Accessory_t shield;
@@ -259,6 +260,7 @@ extern "C" {
 #endif
 
 void Player_Init( Player_t* player, TileMap_t* tileMap );
+void Player_SetName( Player_t* player, const char* name );
 uint8_t Player_GetLevelFromExperience( uint16_t experience );
 uint8_t Player_GetStrengthFromLevel( Player_t* player, uint8_t level );
 uint8_t Player_GetAgilityFromLevel( Player_t* player, uint8_t level );

--- a/DragonQuestino/player.h
+++ b/DragonQuestino/player.h
@@ -260,6 +260,10 @@ extern "C" {
 
 void Player_Init( Player_t* player, TileMap_t* tileMap );
 uint8_t Player_GetLevelFromExperience( uint16_t experience );
+uint8_t Player_GetStrengthFromLevel( Player_t* player, uint8_t level );
+uint8_t Player_GetAgilityFromLevel( Player_t* player, uint8_t level );
+uint8_t Player_GetMaxHitPointsFromLevel( Player_t* player, uint8_t level );
+uint8_t Player_GetMaxMagicPointsFromLevel( Player_t* player, uint8_t level );
 uint16_t Player_GetExperienceRemaining( Player_t* player );
 uint8_t Player_RestoreHitPoints( Player_t* player, uint8_t hitPoints );
 Bool_t Player_CollectItem( Player_t* player, Item_t item );

--- a/DragonQuestinoPasswordGenerator/DragonQuestinoPasswordGenerator/MainWindow.xaml
+++ b/DragonQuestinoPasswordGenerator/DragonQuestinoPasswordGenerator/MainWindow.xaml
@@ -46,6 +46,8 @@
                            GotFocus="TextBox_GotFocus_SelectText"
                            Text="{Binding PlayerName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                </StackPanel>
+               <TextBlock Text="{Binding StatGrowthText}"
+                          Margin="80 0 0 0"/>
                <StackPanel Orientation="Horizontal">
                   <Label Content="Experience:" />
                   <TextBox PreviewTextInput="TextBox_PreviewTextInput_NumericOnly"

--- a/DragonQuestinoPasswordGenerator/DragonQuestinoPasswordGenerator/ViewModels/MainWindowViewModel.cs
+++ b/DragonQuestinoPasswordGenerator/DragonQuestinoPasswordGenerator/ViewModels/MainWindowViewModel.cs
@@ -1241,16 +1241,16 @@ namespace DragonQuestinoPasswordGenerator.ViewModels
          switch( nameSum % 4 )
          {
             case 0:
-               StatGrowthText = string.Format( "(S.T. strength and agility by {0})", statFactor );
+               StatGrowthText = string.Format( "(short term str and agl by {0})", statFactor );
                break;
             case 1:
-               StatGrowthText = string.Format( "(S.T. agility and MP by {0})", statFactor );
+               StatGrowthText = string.Format( "(short term agl and MP by {0})", statFactor );
                break;
             case 2:
-               StatGrowthText = string.Format( "(S.T. strength and HP by {0})", statFactor );
+               StatGrowthText = string.Format( "(short term str and HP by {0})", statFactor );
                break;
             case 3:
-               StatGrowthText = string.Format( "(S.T. HP and MP by {0})", statFactor );
+               StatGrowthText = string.Format( "(short term HP and MP by {0})", statFactor );
                break;
          }
       }

--- a/DragonQuestinoPasswordGenerator/DragonQuestinoPasswordGenerator/ViewModels/MainWindowViewModel.cs
+++ b/DragonQuestinoPasswordGenerator/DragonQuestinoPasswordGenerator/ViewModels/MainWindowViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using DragonQuestinoPasswordGenerator.Commands;
 using System;
 using System.Collections.ObjectModel;
+using System.Numerics;
 using System.Windows;
 using System.Windows.Input;
 
@@ -95,7 +96,18 @@ namespace DragonQuestinoPasswordGenerator.ViewModels
             if ( SetProperty( ref _playerName, value ) )
             {
                UpdatePassword();
+               UpdateStatGrowthText();
             }
+         }
+      }
+
+      private string _statGrowthText = string.Empty;
+      public string StatGrowthText
+      {
+         get => _statGrowthText;
+         set
+         {
+            SetProperty( ref _statGrowthText, value );
          }
       }
 
@@ -1086,6 +1098,7 @@ namespace DragonQuestinoPasswordGenerator.ViewModels
          _selectedShield = Shields[0];
 
          UpdatePassword();
+         UpdateStatGrowthText();
       }
 
       private void UpdatePassword()
@@ -1214,6 +1227,33 @@ namespace DragonQuestinoPasswordGenerator.ViewModels
          Password = new( passwordChars );
       }
 
+      private void UpdateStatGrowthText()
+      {
+         int nameSum = 0;
+
+         for ( int i = 0; i < PlayerName.Length; i++ )
+         {
+            nameSum += PlayerName[i] % 16;
+         }
+
+         int statFactor = ( nameSum / 4 ) % 4;
+
+         switch( nameSum % 4 )
+         {
+            case 0:
+               StatGrowthText = string.Format( "(S.T. strength and agility by {0})", statFactor );
+               break;
+            case 1:
+               StatGrowthText = string.Format( "(S.T. agility and MP by {0})", statFactor );
+               break;
+            case 2:
+               StatGrowthText = string.Format( "(S.T. strength and HP by {0})", statFactor );
+               break;
+            case 3:
+               StatGrowthText = string.Format( "(S.T. HP and MP by {0})", statFactor );
+               break;
+         }
+      }
 
       private void EnterPassword()
       {


### PR DESCRIPTION
## Overview

In the original game, there's an algorithm that happens when you enter the player's name, which ultimately determines your "stat growth type". I'm adapting it just slightly, in order to make it easier. It's just as random though, here's how it works:

First, take each character of the name, do a `% 16` on it (the original game had a lookup table), sum them all up, then do a `% 4`, giving you a number from 0 to 3. This number corresponds to a stat growth type:

0 - Short term strength and agility
1 - Short term agility and MP
2 - Short term strength and HP
3 - Short term HP and MP

"Short term" growth means that the player will initially have higher-than-normal values for the corresponding stats, but eventually will have less-than-normal later on. This is opposed to "long term" growth, which just takes the values straight from the stats tables. Here's how short term growth is calculated:

- Take the same sum we did earlier for all the characters in the player's name, but this time divide it by 4.
- Divide that number by 4, then do a `% 4`, giving you a number from 0 to 3.
- Get the stat value from its corresponding table, and multiply it by 9/10, then add the result from the previous step.

The whole idea is that early on, you might end up with higher stats, but later on they'll be lower, although it is possible to end up with LESS than the normal amount from the very start (if your add-on number is zero, or even 1).

I have no idea why they do things this way, but if it more or less matches the tech guide, I guess we'll go with it.