### PR TITLE
Close temporary doors on password entry

### DIFF
--- a/DragonQuestino/game_password.c
+++ b/DragonQuestino/game_password.c
@@ -127,7 +127,7 @@ Bool_t Game_LoadFromPassword( Game_t* game, const char* password )
 
    Password_ExtractPlayerName( player, encodedBits );
 
-   game->gameFlags.doors = encodedBits[0] >> 16;
+   game->gameFlags.doors = 0xFFFF0000 | ( encodedBits[0] >> 16 );
    game->gameFlags.treasures = encodedBits[1];
    game->gameFlags.specialEnemies = (u8)( ( encodedBits[3] >> 5 ) & 0x7 );
    game->gameFlags.rescuedPrincess = (Bool_t)( ( encodedBits[3] >> 4 ) & 0x1 );


### PR DESCRIPTION
Addresses issue: #166 

## Overview

This is another case of me forgetting that door flags are reversed, so `1` means the door is *closed*. So there was a bug where entering a password sets all the temporary doors to `0`, meaning all the Tantegel temporary doors are opened until you leave the castle.

In the linked issue, I thought there was also a problem with the name, but I'm not seeing that at all now, so I probably just entered the password incorrectly once.