### PR TITLE
Hauksness monsters should have a black backdrop

### DIFF
--- a/DragonQuestino/animation_chain.c
+++ b/DragonQuestino/animation_chain.c
@@ -436,7 +436,7 @@ internal void AnimationChain_Tic_Battle_Checkerboard( AnimationChain_t* chain )
 
       while ( g_squaresDrawn <= squaresToDraw )
       {
-         if ( chain->tileMap->isDungeon )
+         if ( chain->tileMap->isDungeon || chain->tileMap->id == TILEMAP_HAUKSNESS_ID )
          {
             xOffset = chain->tileMap->isDark ? -24 : 0;
             yOffset = chain->tileMap->isDark ? 4 : 0;

--- a/DragonQuestino/game_render.c
+++ b/DragonQuestino/game_render.c
@@ -328,7 +328,7 @@ void Game_DrawBattleBackground( Game_t* game )
    {
       Screen_DrawRectColor( &( game->screen ), 72, 56, 112, 112, COLOR_BLACK );
    }
-   else if ( game->tileMap.isDungeon )
+   else if ( game->tileMap.isDungeon || game->tileMap.id == TILEMAP_HAUKSNESS_ID )
    {
       Screen_DrawRectColor( &( game->screen ), x, y, 112, 112, COLOR_BLACK );
    }


### PR DESCRIPTION
Addresses issue: #165 

## Overview

Technically Hauksness isn't a dungeon, and we don't want to make it one, because then you couldn't cast certain spells. But we do want to draw the black backdrop during battles, so this just adds a few checks to make sure we do that.