### PR TITLE
Bugfix: NPCs that don't wander should not be wandering

### DIFF
--- a/DragonQuestino/game_physics.c
+++ b/DragonQuestino/game_physics.c
@@ -161,8 +161,8 @@ void Game_TicPhysics( Game_t* game )
    player->velocity.x = 0;
    player->velocity.y = 0;
 
-   Game_UpdatePlayerTileIndex( game );
    Game_MoveNpcs( game );
+   Game_UpdatePlayerTileIndex( game );
 
 #if defined( VISUAL_STUDIO_DEV )
    if ( !g_debugFlags.noTileDamage ) {

--- a/DragonQuestino/tile_map.c
+++ b/DragonQuestino/tile_map.c
@@ -65,6 +65,8 @@ void TileMap_ResetNpcs( TileMap_t* tileMap )
 
    for ( i = 0; i < tileMap->npcCount; i++ )
    {
+      tileMap->npcs[i].isWandering = False;
+
       if ( tileMap->npcs[i].wanders )
       {
          TileMap_StopNpc( &( tileMap->npcs[i] ) );


### PR DESCRIPTION
Addresses issue: #149 

## Overview

This one was pretty tricky to find. When we reset NPCs, we only set `isWandering` to false if the NPC is a wandering type. This was getting us into an odd situation where if you step on a portal while an NPC is moving, we load all the NPCs for the new map and reset all of them, but some of them may still have `isWandering == True` even though they don't wander, which causes us to draw them in the wrong location. To fix that, we can just make sure `isWandering` is always false when resetting.