### PR TITLE
Bugfix: The player and enemies should actually wake up when waking up

### DIFF
--- a/DragonQuestino/battle.c
+++ b/DragonQuestino/battle.c
@@ -566,6 +566,7 @@ internal void Battle_SwitchTurnCallback( Battle_t* battle )
 
          if ( Random_u8( 1, 2 ) == 1 )
          {
+            battle->game->player.stats.isAsleep = False;
             Dialog_PushSectionWithCallback( &( battle->game->dialog ), STRING_BATTLE_PLAYERWOKEUP, Game_ResetBattleMenu, battle->game );
          }
          else
@@ -611,6 +612,7 @@ internal void Battle_EnemyTurn( Battle_t* battle )
    {
       if ( Random_u8( 1, 3 ) == 1 )
       {
+         battle->enemy.stats.isAsleep = False;
          Dialog_Reset( &( battle->game->dialog ) );
          sprintf( msg, STRING_BATTLE_ENEMYWOKEUP, battle->enemy.name );
          Dialog_PushSectionWithCallback( &( battle->game->dialog ), msg, Battle_EnemyWokeUpCallback, battle );


### PR DESCRIPTION
Addresses issue: #183 

## Overview

This was quite an oversight, when the player or an enemy wakes up, they never actually wake up, in that their sleep flag never gets flipped to true. That means they'll be able to get one single turn in, before going to sleep again.