### PR TITLE
Increase message size to avoid crash

### DIFF
--- a/DragonQuestino/game_physics.c
+++ b/DragonQuestino/game_physics.c
@@ -194,7 +194,7 @@ void Game_TicPhysics( Game_t* game )
 void Game_PlayerSteppedOnTile( Game_t* game )
 {
    TilePortal_t* portal;
-   char msg[64];
+   char msg[128];
 
 #if defined VISUAL_STUDIO_DEV
    if ( !g_debugFlags.noTileDamage )


### PR DESCRIPTION
Addresses Issue: #184 

## Overview

If your character's name is long enough, then the game will crash when you walk into any town other Tantegel while carrying the princess. I just had to increase the size of the message string, now it's fine.