### PR TITLE
Remove Sphere of Light from password generation

### DIFF
--- a/DragonQuestinoPasswordGenerator/DragonQuestinoPasswordGenerator/MainWindow.xaml
+++ b/DragonQuestinoPasswordGenerator/DragonQuestinoPasswordGenerator/MainWindow.xaml
@@ -209,8 +209,6 @@
                                IsChecked="{Binding HasErdricksToken, Mode=TwoWay}" />
                      <CheckBox Content="Rainbow Drop"
                                IsChecked="{Binding HasRainbowDrop, Mode=TwoWay}" />
-                     <CheckBox Content="Sphere of Light"
-                               IsChecked="{Binding HasSphereOfLight, Mode=TwoWay}" />
                   </StackPanel>
                </GroupBox>
 
@@ -315,7 +313,8 @@
 
          <!-- RIGHT PANEL, BOTTOM SECTION -->
          <StackPanel Orientation="Horizontal"
-                     HorizontalAlignment="Center">
+                     HorizontalAlignment="Center"
+                     Margin="0 18 0 0" >
 
             <!-- PASSWORD-->
             <GroupBox Header="Password">


### PR DESCRIPTION
Addresses Issue: #185 

## Overview

This must be an artifact of changing how passwords worked in the past, the Sphere of Light used to be saved. I think I missed removing it because for some reason solution-wide searches don't include xaml files for me. Anyway, this is purely cosmetic, but needs to be done regardless.