### PR TITLE
Fixed single items in Password Generator

### DIFF
--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -936,7 +936,10 @@ internal void Game_EnterPasswordFadeOutCallback( Game_t* game )
    // to use it, uncomment this line and comment out all the lines below it.
    //Game_Load( game, "UCz..xAgIwBJ........HxHdtPf..4" );
 
-   game->alphaPicker.position.x = 28;
+   // MUFFINS: delete this later
+   Game_Load( game, "eAwOvX-AAAAAEAxeBqS2sBmq2pnrYf" );
+
+   /*game->alphaPicker.position.x = 28;
    game->alphaPicker.position.y = 28;
-   AlphaPicker_Reset( &( game->alphaPicker ), STRING_ALPHAPICKER_PASSWORD_TITLE, True );
+   AlphaPicker_Reset( &( game->alphaPicker ), STRING_ALPHAPICKER_PASSWORD_TITLE, True );*/
 }

--- a/DragonQuestinoPasswordGenerator/DragonQuestinoPasswordGenerator/ViewModels/MainWindowViewModel.cs
+++ b/DragonQuestinoPasswordGenerator/DragonQuestinoPasswordGenerator/ViewModels/MainWindowViewModel.cs
@@ -1,7 +1,5 @@
 ﻿using DragonQuestinoPasswordGenerator.Commands;
-using System;
 using System.Collections.ObjectModel;
-using System.Numerics;
 using System.Windows;
 using System.Windows.Input;
 
@@ -1491,6 +1489,16 @@ namespace DragonQuestinoPasswordGenerator.ViewModels
          WingCount = ( ( flags >> 6 ) & 0x7 ).ToString();
          FairyWaterCount = ( ( flags >> 9 ) & 0x7 ).ToString();
          TorchCount = ( ( flags >> 12 ) & 0x7 ).ToString();
+
+         HasFairyFlute = ( ( flags >> 15 ) & 0x1 ) != 0;
+         HasSilverHarp = ( ( flags >> 16 ) & 0x1 ) != 0;
+         HasGwaelinsLove = ( ( flags >> 17 ) & 0x1 ) != 0;
+         HasStoneOfSunlight = ( ( flags >> 18 ) & 0x1 ) != 0;
+         HasStaffOfRain = ( ( flags >> 19 ) & 0x1 ) != 0;
+         HasErdricksToken = ( ( flags >> 20 ) & 0x1 ) != 0;
+         HasRainbowDrop = ( ( flags >> 21 ) & 0x1 ) != 0;
+         HasDragonScale = ( ( flags >> 23 ) & 0x1 ) != 0;
+         HasCursedBelt = ( ( flags >> 24 ) & 0x1 ) != 0;
       }
 
       private UInt32 GetTownVisitedFlags()


### PR DESCRIPTION
Addresses Issue: #193 

## Overview

Again, not sure how I overlooked this, but the password generator was ignoring single-use items when generating passwords. This should fix that.