### PR TITLE
Bugfix: special enemy flags in passwords

### DIFF
--- a/DragonQuestino/game_password.c
+++ b/DragonQuestino/game_password.c
@@ -15,25 +15,25 @@ void Game_GetPassword( Game_t* game, char* password )
    Player_t* player = &( game->player );
 
    u32 encodedBits[6] = {
-      ( game->gameFlags.doors << 16 ) |                              // doors not opened (16 bits)
-      ( player->experience ),                                        // experience (16 bits)
+      ( game->gameFlags.doors << 16 ) |                                    // doors not opened (16 bits)
+      ( player->experience ),                                              // experience (16 bits)
 
-      game->gameFlags.treasures,                                     // treasures remaining (32 bits)
+      game->gameFlags.treasures,                                           // treasures remaining (32 bits)
 
-      ( player->items << 7 ) |                                       // items (25 bits)
-      ( (u32)( player->townsVisited & 0x3F ) << 1 ) |                // towns visited (6 bits)
-      0x0,                                                           // reserved (1 bit)
+      ( player->items << 7 ) |                                             // items (25 bits)
+      ( (u32)( player->townsVisited & 0x3F ) << 1 ) |                      // towns visited (6 bits)
+      0x0,                                                                 // reserved (1 bit)
 
-      ( (u32)( player->gold ) << 16 ) |                              // gold (16 bits)
-      ( (u32)( player->weapon.id & 0x7 ) << 13 ) |                   // weapon (3 bits)
-      ( (u32)( player->armor.id & 0x7 ) << 10 ) |                    // armor (3 bits)
-      ( (u32)( player->shield.id & 0x3 ) << 8 ) |                    // shield (2 bits)
-      ( (u32)( game->gameFlags.specialEnemies & 0x7 ) << 5 ) |       // special enemies not defeated (3 bits)
-      ( game->gameFlags.rescuedPrincess ? ( 0x1 << 4 ) : 0x0 ) |     // rescued princess (1 bit)
-      ( game->gameFlags.foundHiddenStairs ? ( 0x1 << 3 ) : 0x0 ) |   // found hidden stairs (1 bit)
-      ( game->gameFlags.usedRainbowDrop ? ( 0x1 << 2 ) : 0x0 ) |     // used rainbow drop (1 bit)
-      ( game->gameFlags.gotStaffOfRain ? ( 0x1 << 1 ) : 0x0 ) |      // got the staff of rain (1 bit)
-      ( game->gameFlags.gotRainbowDrop ? 0x1 : 0x0 )                 // got the rainbow drop (1 bit)
+      ( (u32)( player->gold ) << 16 ) |                                    // gold (16 bits)
+      ( (u32)( player->weapon.id & 0x7 ) << 13 ) |                         // weapon (3 bits)
+      ( (u32)( player->armor.id & 0x7 ) << 10 ) |                          // armor (3 bits)
+      ( (u32)( player->shield.id & 0x3 ) << 8 ) |                          // shield (2 bits)
+      ( (u32)( ( game->gameFlags.specialEnemies >> 1 ) & 0x7 ) << 5 ) |    // special enemies not defeated (3 bits)
+      ( game->gameFlags.rescuedPrincess ? ( 0x1 << 4 ) : 0x0 ) |           // rescued princess (1 bit)
+      ( game->gameFlags.foundHiddenStairs ? ( 0x1 << 3 ) : 0x0 ) |         // found hidden stairs (1 bit)
+      ( game->gameFlags.usedRainbowDrop ? ( 0x1 << 2 ) : 0x0 ) |           // used rainbow drop (1 bit)
+      ( game->gameFlags.gotStaffOfRain ? ( 0x1 << 1 ) : 0x0 ) |            // got the staff of rain (1 bit)
+      ( game->gameFlags.gotRainbowDrop ? 0x1 : 0x0 )                       // got the rainbow drop (1 bit)
    };
 
    // the player's encoded name goes on the end, followed by its length
@@ -129,7 +129,7 @@ Bool_t Game_LoadFromPassword( Game_t* game, const char* password )
 
    game->gameFlags.doors = 0xFFFF0000 | ( encodedBits[0] >> 16 );
    game->gameFlags.treasures = encodedBits[1];
-   game->gameFlags.specialEnemies = (u8)( ( encodedBits[3] >> 5 ) & 0x7 );
+   game->gameFlags.specialEnemies = (u8)( ( ( encodedBits[3] >> 5 ) & 0x7 ) << 1 );
    game->gameFlags.rescuedPrincess = (Bool_t)( ( encodedBits[3] >> 4 ) & 0x1 );
    game->gameFlags.foundHiddenStairs = (Bool_t)( ( encodedBits[3] >> 3 ) & 0x1 );
    game->gameFlags.usedRainbowDrop = (Bool_t)( ( encodedBits[3] >> 2 ) & 0x1 );


### PR DESCRIPTION
Addresses Issue: #196 

## Overview

Yet another password bug. This time, the special enemy flags were being stored incorrectly. Awesome.