### PR TITLE
Bugfix: Player shouldn't flicker after portaling to a new destination

### DIFF
--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -379,6 +379,7 @@ void Game_EnterTargetPortal( Game_t* game )
    // the player sprite gets caught on unpassable tiles unless we use COLLISION_THETA here, but for some reason the x-axis has no problems
    game->player.sprite.position.y = (r32)( ( i32 )( TILE_SIZE * ( destinationTileIndex / game->tileMap.tilesX ) ) - game->player.sprite.offset.y ) - COLLISION_THETA;
    game->player.tileIndex = destinationTileIndex;
+   Player_SetCanonicalTileIndex( &( game->player ) );
    game->player.maxVelocity = TileMap_GetWalkSpeedForTileIndex( &( game->tileMap ), destinationTileIndex );
    game->targetPortal = 0;
 


### PR DESCRIPTION
Addresses Issue: #192 

## Overview

I found this when entering the swamp cave, the player would still flicker until stepping on a new tile. This is because we weren't updating the player's canonical tile index after taking a portal, so it still thought we were in the swamp.