### PR TITLE
Bugfix: Evac in the swamp cave should go to correct exit

### DIFF
--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -161,6 +161,8 @@ void Game_Load( Game_t* game, const char* password )
 
    TileMap_LoadTextures( &( game->tileMap ), TileTextureType_Map );
    TileMap_Load( &( game->tileMap ), TILEMAP_TANTEGEL_THRONEROOM_ID );
+   game->tileMap.previousId = game->tileMap.id;
+   game->tileMap.lastPortalTileIndex = 0;
    player->tileIndex = 128; // in front of King Lorik
    Player_SetCanonicalTileIndex( player );
 
@@ -373,6 +375,8 @@ void Game_EnterTargetPortal( Game_t* game )
       case TILEMAP_RIMULDAR_ID: SET_VISITED_RIMULDAR( game->player.townsVisited ); break;
    }
 
+   game->tileMap.previousId = game->tileMap.id;
+   game->tileMap.lastPortalTileIndex = game->player.tileIndex;
    TileMap_Load( &( game->tileMap ), game->targetPortal->destinationTileMapIndex );
 
    game->player.sprite.position.x = (r32)( ( i32 )( TILE_SIZE * ( destinationTileIndex % game->tileMap.tilesX ) ) - game->player.sprite.offset.x ) + COLLISION_THETA;

--- a/DragonQuestino/game_spells.c
+++ b/DragonQuestino/game_spells.c
@@ -519,6 +519,12 @@ internal void Game_SpellEvacCallback( Game_t* game )
    }
    else
    {
+      if ( ( game->tileMap.previousId == TILEMAP_OVERWORLD_ID ) && ( game->tileMap.id == TILEMAP_SWAMPCAVE_ID ) )
+      {
+         // this is a special case for the swamp cave, since it has two entrances
+         game->tileMap.evacPortal.destinationTileIndex = game->tileMap.lastPortalTileIndex;
+      }
+
       AnimationChain_Reset( &( game->animationChain ) );
       Game_AnimatePortalEntrance( game, &( game->tileMap.evacPortal ) );
       AnimationChain_Start( &( game->animationChain ) );

--- a/DragonQuestino/tile_map.h
+++ b/DragonQuestino/tile_map.h
@@ -172,6 +172,7 @@ typedef struct TileMap_t
    Player_t* player;
 
    u32 id;
+   u32 previousId;
 
    Bool_t hasEncounters;
    Bool_t blocksMagic;
@@ -200,6 +201,7 @@ typedef struct TileMap_t
    TilePortal_t portals[TILEMAP_MAX_PORTALS];
    u32 portalCount;
    TilePortal_t evacPortal;
+   u32 lastPortalTileIndex;
 
    EnemyIndexPool_t overworldEnemyIndexPools[TILE_OVERWORLD_ENEMY_INDEX_POOLS];
    EnemyIndexPool_t dungeonEnemyIndexPools[TILE_DUNGEON_ENEMY_INDEX_POOLS];


### PR DESCRIPTION
Addresses issue: #195 

## Overview

The swamp cave needs a special case when casting eval, because it has two entrances and should choose the correct one that you came from. We can do this by just saving the last portal tile index and setting it as the evac destination tile index. Note that this wouldn't work if the swamp cave had multiple floors.