### PR TITLE
Bugfix: Fizzled enemies can still cast spells

### DIFF
--- a/DragonQuestino/battle.c
+++ b/DragonQuestino/battle.c
@@ -44,6 +44,8 @@ internal void Battle_EnemyBreatheFireCallback( Battle_t* battle );
 internal void Battle_EnemyBreatheStrongFire( Battle_t* battle );
 internal void Battle_EnemyBreatheStrongFireCallback( Battle_t* battle );
 internal void Battle_EnemyCastSpell( Battle_t* battle, const char* spellName, void ( *callback )( Battle_t* ) );
+internal void Battle_EnemySpellFizzledCallback( Battle_t* battle );
+internal void Battle_EnemySpellFizzledMessageCallback( Battle_t* battle );
 internal void Battle_EnemyCastSizz( Battle_t* battle );
 internal void Battle_EnemyCastSizzCallback( Battle_t* battle );
 internal void Battle_EnemyCastSizzle( Battle_t* battle );
@@ -925,7 +927,25 @@ internal void Battle_EnemyCastSpell( Battle_t* battle, const char* spellName, vo
 
    Dialog_Reset( &( battle->game->dialog ) );
    sprintf( msg, STRING_BATTLE_ENEMY_SPELLCAST, battle->enemy.name, spellName );
-   Dialog_PushSectionWithCallback( &( battle->game->dialog ), msg, callback, battle );
+   Dialog_PushSectionWithCallback( &( battle->game->dialog ), msg, ( battle->enemy.stats.isFizzled ) ? Battle_EnemySpellFizzledCallback : callback, battle );
+   Game_OpenDialog( battle->game );
+}
+
+internal void Battle_EnemySpellFizzledCallback( Battle_t* battle )
+{
+   AnimationChain_Reset( &( battle->game->animationChain ) );
+   AnimationChain_PushAnimation( &( battle->game->animationChain ), AnimationId_CastSpell );
+   AnimationChain_PushAnimationWithCallback( &( battle->game->animationChain ), AnimationId_Pause, Battle_EnemySpellFizzledMessageCallback, battle );
+   Battle_EnemyAnimateSpellWithCallback( battle, Battle_EnemySpellFizzledMessageCallback );
+   AnimationChain_Start( &( battle->game->animationChain ) );
+}
+
+internal void Battle_EnemySpellFizzledMessageCallback( Battle_t* battle )
+{
+   battle->turn = BattleTurn_Player;
+
+   Dialog_Reset( &( battle->game->dialog ) );
+   Dialog_PushSectionWithCallback( &( battle->game->dialog ), STRING_BATTLE_SPELLFIZZLEDCOMMAND, Game_ResetBattleMenu, battle->game );
    Game_OpenDialog( battle->game );
 }
 

--- a/DragonQuestino/strings.h
+++ b/DragonQuestino/strings.h
@@ -295,6 +295,7 @@
 #define STRING_BATTLE_NOTENOUGHMP                                    "You do not have enough MP. Command?"
 #define STRING_BATTLE_SPELLCAST                                      "You cast %s!"
 #define STRING_BATTLE_SPELLFIZZLED                                   "But the spell has been blocked!"
+#define STRING_BATTLE_SPELLFIZZLEDCOMMAND                            "But the spell has been blocked! Command?"
 #define STRING_BATTLE_FULLYHEALED                                    "You are already fully healed. Command?"
 #define STRING_BATTLE_SPELL_NOEFFECT                                 "But the spell has no effect on the %s!"
 #define STRING_BATTLE_SPELL_SLEEP_ALREADYASLEEP                      "The %s is already asleep. Command?"


### PR DESCRIPTION
Addresses Issue: #208 

## Overview

We've accounted for everything fizzle-related, except for actually enforcing it on enemies. This just makes sure that enemies that are fizzled can't cast spells.