### PR TITLE
Bugfix: healing spell blip in the overworld

### DIFF
--- a/DragonQuestino/game_render.c
+++ b/DragonQuestino/game_render.c
@@ -45,6 +45,9 @@ void Game_Draw( Game_t* game )
 
             if ( game->subState == SubState_Dialog )
             {
+               // TODO: this fixes the "blip" when casting heal spells in the overworld,
+               // but I don't really know the full ramifications elsewhere. keep an eye on this.
+               Game_DrawQuickStatus( game );
                Dialog_Draw( &( game->dialog ) );
             }
          }


### PR DESCRIPTION
Addresses card: #168 

## Overview

When you cast a healing spell in the overworld, there's a chance the quick stats window will disappear for a split second and the re-appear. I *think* this fixes the issue, but there's a chance it'll cause other issues, so I need to keep an eye on that.