### PR TITLE
Bugfix: Reset the tilemap viewport after death

### DIFF
--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -585,6 +585,7 @@ internal void Game_DeathFadeOutCallback( Game_t* game )
    }
 
    TileMap_Load( &( game->tileMap ), TILEMAP_TANTEGEL_THRONEROOM_ID );
+   TileMap_ResetViewport( &( game->tileMap ) );
    game->player.tileIndex = 128;
    Player_SetCanonicalTileIndex( &( game->player ) );
    Player_CenterOnTile( &( game->player ) );
@@ -939,9 +940,9 @@ internal void Game_EnterPasswordFadeOutCallback( Game_t* game )
 
    // MUFFINS: this gives us some goodies for testing (level 30 with everything except a few treasures).
    // to use it, uncomment this line and comment out all the lines below it.
-   //Game_Load( game, "UCz..xAgIwBJ........HxHdtPf..4" );
+   Game_Load( game, "UCz..xAgIwBJ........HxHdtPf..4" );
 
-   game->alphaPicker.position.x = 28;
+   /*game->alphaPicker.position.x = 28;
    game->alphaPicker.position.y = 28;
-   AlphaPicker_Reset( &( game->alphaPicker ), STRING_ALPHAPICKER_PASSWORD_TITLE, True );
+   AlphaPicker_Reset( &( game->alphaPicker ), STRING_ALPHAPICKER_PASSWORD_TITLE, True );*/
 }


### PR DESCRIPTION
Addresses issue: #222 

## Overview

If you die in a dungeon, the tilemap viewport should reset when you come back to life.