### PR TITLE
Swap Cantlin and Rimuldar in the zoom order

### DIFF
--- a/DragonQuestino/menu.c
+++ b/DragonQuestino/menu.c
@@ -469,16 +469,16 @@ internal void Menu_UpdateZoom( Menu_t* menu )
       menu->items[i].command = MenuCommand_Zoom_Kol;
       i++;
    }
-   if ( HAS_VISITED_CANTLIN( tv ) )
-   {
-      strcpy( menu->items[i].text, STRING_TOWN_CANTLIN );
-      menu->items[i].command = MenuCommand_Zoom_Cantlin;
-      i++;
-   }
    if ( HAS_VISITED_RIMULDAR( tv ) )
    {
       strcpy( menu->items[i].text, STRING_TOWN_RIMULDAR );
       menu->items[i].command = MenuCommand_Zoom_Rimuldar;
+      i++;
+   }
+   if ( HAS_VISITED_CANTLIN( tv ) )
+   {
+      strcpy( menu->items[i].text, STRING_TOWN_CANTLIN );
+      menu->items[i].command = MenuCommand_Zoom_Cantlin;
    }
 }
 

--- a/DragonQuestino/player.h
+++ b/DragonQuestino/player.h
@@ -135,23 +135,23 @@ typedef struct TileMap_t TileMap_t;
 #define HAS_VISITED_BRECCONARY( x )             ( x ) & 0x2
 #define HAS_VISITED_GARINHAM( x )               ( x ) & 0x4
 #define HAS_VISITED_KOL( x )                    ( x ) & 0x8
-#define HAS_VISITED_CANTLIN( x )                ( x ) & 0x10
 #define HAS_VISITED_RIMULDAR( x )               ( x ) & 0x20
+#define HAS_VISITED_CANTLIN( x )                ( x ) & 0x10
 
 #define HAS_VISITED_COUNT( x )                  ( 0 + \
                                                 ( HAS_VISITED_TANTEGEL( x ) ? 1 : 0 ) + \
                                                 ( HAS_VISITED_BRECCONARY( x ) ? 1 : 0 ) + \
                                                 ( HAS_VISITED_GARINHAM( x ) ? 1 : 0 ) + \
                                                 ( HAS_VISITED_KOL( x ) ? 1 : 0 ) + \
-                                                ( HAS_VISITED_CANTLIN( x ) ? 1 : 0 ) + \
-                                                ( HAS_VISITED_RIMULDAR( x ) ? 1 : 0 ) )
+                                                ( HAS_VISITED_RIMULDAR( x ) ? 1 : 0 ) + \
+                                                ( HAS_VISITED_CANTLIN( x ) ? 1 : 0 ) )
 
 #define SET_VISITED_TANTEGEL( x )               ( x ) |= 0x1
 #define SET_VISITED_BRECCONARY( x )             ( x ) |= 0x2
 #define SET_VISITED_GARINHAM( x )               ( x ) |= 0x4
 #define SET_VISITED_KOL( x )                    ( x ) |= 0x8
-#define SET_VISITED_CANTLIN( x )                ( x ) |= 0x10
 #define SET_VISITED_RIMULDAR( x )               ( x ) |= 0x20
+#define SET_VISITED_CANTLIN( x )                ( x ) |= 0x10
 
 #define HOLY_PROTECTION_MAX_STEPS               127
 

--- a/DragonQuestino/strings.h
+++ b/DragonQuestino/strings.h
@@ -82,8 +82,8 @@
 #define STRING_TOWN_BRECCONARY                                       "Brecconary"
 #define STRING_TOWN_GARINHAM                                         "Garinham"
 #define STRING_TOWN_KOL                                              "Kol"
-#define STRING_TOWN_CANTLIN                                          "Cantlin"
 #define STRING_TOWN_RIMULDAR                                         "Rimuldar"
+#define STRING_TOWN_CANTLIN                                          "Cantlin"
 
 #define STRING_OVERWORLD_ITEMMENU_KEY                                "Key     %u"
 #define STRING_OVERWORLD_ITEMMENU_HERB                               "Herb    %u"


### PR DESCRIPTION
Addresses Issue: #239 

## Overview

I didn't realize until playing through the whole game again that you visit Rimuldar long before visiting Cantlin, so Rimuldar should show up first on the list of towns you can zoom to. I didn't change any of the underlying data, but Rimuldar shows up first in the list now.