### PR TITLE
Bugfix: Reset enemy alpha after player death

### DIFF
--- a/DragonQuestino/battle.c
+++ b/DragonQuestino/battle.c
@@ -88,6 +88,7 @@ void Battle_Init( Battle_t* battle, Game_t* game )
    battle->enemy.stats.maxMagicPoints = 0;
 
    battle->specialEnemy = SpecialEnemy_None;
+   battle->enemyAlpha = 0;
 }
 
 void Battle_Generate( Battle_t* battle )

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -593,6 +593,7 @@ internal void Game_DeathFadeOutCallback( Game_t* game )
    Player_CenterOnTile( &( game->player ) );
    ActiveSprite_SetDirection( &( game->player.sprite ), Direction_Up );
    TileMap_UpdateViewport( &( game->tileMap ) );
+   game->battle.enemyAlpha = 0;
 }
 
 internal void Game_DeathPostFadeCallback( Game_t* game )


### PR DESCRIPTION
Addresses Issue: #234 

## Overview

The enemy alpha value is never actually changed outside of initialization and during battle, so if you die during a battle, it stays at 255 even after you respawn. So if you die, after you respawn and get in another fight, the enemy will show up for a split second full-frame, before disappearing and then fading in. This makes sure the enemy alpha is reset after dying.