### PR TITLE
Bugfix: Battle pauses

### DIFF
--- a/DragonQuestino/battle.c
+++ b/DragonQuestino/battle.c
@@ -961,6 +961,7 @@ internal void Battle_EnemyCastSizzCallback( Battle_t* battle )
 
    AnimationChain_Reset( &( battle->game->animationChain ) );
    AnimationChain_PushAnimation( &( battle->game->animationChain ), AnimationId_CastSpell );
+   AnimationChain_PushAnimation( &( battle->game->animationChain ), AnimationId_Pause );
    Battle_PushPlayerHurtAnimation( battle );
    AnimationChain_Start( &( battle->game->animationChain ) );
 }
@@ -980,6 +981,7 @@ internal void Battle_EnemyCastSizzleCallback( Battle_t* battle )
 
    AnimationChain_Reset( &( battle->game->animationChain ) );
    AnimationChain_PushAnimation( &( battle->game->animationChain ), AnimationId_CastSpell );
+   AnimationChain_PushAnimation( &( battle->game->animationChain ), AnimationId_Pause );
    Battle_PushPlayerHurtAnimation( battle );
    AnimationChain_Start( &( battle->game->animationChain ) );
 }

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -946,9 +946,9 @@ internal void Game_EnterPasswordFadeOutCallback( Game_t* game )
    //Game_Load( game, "UCz..xAgIwBJ........HxHdtPf..4" );
 
    // MUFFINS: for pause testing
-   Game_Load( game, "NAhKVz8ACADJ0IN.Jvb.Hxmq2pnrYf" );
+   //Game_Load( game, "NAhKVz8ACADJ0IN.Jvb.Hxmq2pnrYf" );
 
-   /*game->alphaPicker.position.x = 28;
+   game->alphaPicker.position.x = 28;
    game->alphaPicker.position.y = 28;
-   AlphaPicker_Reset( &( game->alphaPicker ), STRING_ALPHAPICKER_PASSWORD_TITLE, True );*/
+   AlphaPicker_Reset( &( game->alphaPicker ), STRING_ALPHAPICKER_PASSWORD_TITLE, True );
 }


### PR DESCRIPTION
Addresses Issue: #241 

## Overview

There are some moments in battle where there should be pauses between actions, but two of them were missing:

- Enemy breathes fire
- Enemy casts a damage spell

This adds those pauses (they were already there for the player casting these same spells against the enemy).