### PR TITLE
Fairy flute should put other enemies to sleep

### DIFF
--- a/DragonQuestino/game_items.c
+++ b/DragonQuestino/game_items.c
@@ -313,7 +313,21 @@ internal void Game_UseFairyFluteCallback( Game_t* game )
 
 internal void Game_UseFairyFluteMessageCallback( Game_t* game )
 {
-   if ( game->battle.specialEnemy == SpecialEnemy_Golem && !game->battle.enemy.stats.isAsleep )
+   Bool_t success = False;
+
+   if ( !( game->battle.enemy.stats.isAsleep ) )
+   {
+      if ( ( game->battle.specialEnemy == SpecialEnemy_Golem ) )
+      {
+         success = True;
+      }
+      else
+      {
+         success = ( ( game->battle.enemy.stats.sleepResist > 0 ) && ( Random_u8( 1, 15 ) <= game->battle.enemy.stats.sleepResist ) ) ? 0 : 1;
+      }
+   }
+
+   if ( success )
    {
       Game_SpellSleepSuccessCallback( game );
    }

--- a/DragonQuestino/game_spells.c
+++ b/DragonQuestino/game_spells.c
@@ -409,6 +409,7 @@ internal void Game_SpellHurtCallback( Game_t* game )
 
 internal void Game_SpellSleepCallback( Game_t* game )
 {
+   // MUFFINS: here we go
    if ( game->pendingPayload8u == 0 )
    {
       Game_SpellAnimateNoEffect( game );


### PR DESCRIPTION
Addresses Issue: #240 

## Overview

I don't think this actually happens in the original Dragon Warrior, but I feel like using the Fairy Flute on enemies other than the Golem should have the same effect as the sleep spell, so that's what this PR does.