### PR TITLE
Bugfix: more text changes

### DIFF
--- a/DragonQuestino/game_spells.c
+++ b/DragonQuestino/game_spells.c
@@ -409,7 +409,6 @@ internal void Game_SpellHurtCallback( Game_t* game )
 
 internal void Game_SpellSleepCallback( Game_t* game )
 {
-   // MUFFINS: here we go
    if ( game->pendingPayload8u == 0 )
    {
       Game_SpellAnimateNoEffect( game );

--- a/DragonQuestino/strings.h
+++ b/DragonQuestino/strings.h
@@ -30,7 +30,7 @@
 #define STRING_SPELL_EVAC                                            "Evac"
 #define STRING_SPELL_ZOOM                                            "Zoom"
 #define STRING_SPELL_REPEL                                           "Repel"
-#define STRING_SPELL_MIDHEAL                                         "Midheal"
+#define STRING_SPELL_MIDHEAL                                         "Cure"
 #define STRING_SPELL_SIZZLE                                          "Sizzle"
 
 #define STRING_ACCESSORY_NONE                                        "(none)"


### PR DESCRIPTION
Addresses Issues:

#253 
#254 

## Overview

This is just some more dialog fixes:

- Anywhere it says "chimaera wing", it should just say "wing".
- The spell "midheal" is now "cure".