### PR TITLE
Clear the password after loading

### DIFF
--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -131,6 +131,7 @@ void Game_Load( Game_t* game, const char* password )
    {
       if ( Game_LoadFromPassword( game, password ) )
       {
+         game->password[0] = 0;
          game->gameFlags.leftThroneRoom = True;
       }
       else
@@ -943,7 +944,7 @@ internal void Game_EnterPasswordFadeOutCallback( Game_t* game )
 
    // MUFFINS: this gives us some goodies for testing (level 30 with everything except a few treasures).
    // to use it, uncomment this line and comment out all the lines below it.
-   //Game_Load( game, "UCz..xAgIwBJ........HxHdtPf..4" );
+   //Game_Load( game, "2Ah1RBAAAADJ0LP.jev.Hxmq2pnrYf" );
 
    game->alphaPicker.position.x = 28;
    game->alphaPicker.position.y = 28;


### PR DESCRIPTION
Addresses Issue: #258 

## Overview

After entering a password and starting the game, the password stays around, so the next time you enter that screen it's still there. I noticed it after accidentally joining the Dragonlord and then trying to enter a password again (there are probably other ways to make it happen as well). This just makes sure we clear it out after successfully loading the game.