### PR TITLE
Bugfix: Outro player name should be upper-case

### DIFF
--- a/DragonQuestino/game_render.c
+++ b/DragonQuestino/game_render.c
@@ -2,6 +2,7 @@
 #include "battle.h"
 #include "enemy.h"
 #include "math.h"
+#include "string_util.h"
 
 internal void Game_DrawPlayer( Game_t* game );
 internal void Game_DrawNonUseableItems( Game_t* game, Bool_t hasUseableItems );
@@ -648,6 +649,7 @@ internal void Game_DrawEnding1( Game_t* game )
    game->screen.textColor = COLOR_ENDINGYELLOW;
    Screen_DrawCenteredText( &( game->screen ), STRING_ENDING_MESSAGE_1, 32 );
    sprintf( msg, STRING_ENDING_MESSAGE_2, game->player.name );
+   StringUtil_ToUpper( msg );
    Screen_DrawCenteredText( &( game->screen ), msg, 48 );
    Screen_DrawCenteredText( &( game->screen ), STRING_ENDING_MESSAGE_3, 64 );
    Screen_DrawCenteredText( &( game->screen ), STRING_ENDING_MESSAGE_4, 80 );

--- a/DragonQuestino/string_util.c
+++ b/DragonQuestino/string_util.c
@@ -1,0 +1,14 @@
+#include "string_util.h"
+
+void StringUtil_ToUpper( char* str )
+{
+   size_t i;
+
+   for ( i = 0; i < strlen( str ); i++ )
+   {
+      if ( ( str[i] >= 97 ) && ( str[i] <= 122 ) )
+      {
+         str[i] -= 32;
+      }
+   }
+}

--- a/DragonQuestino/string_util.h
+++ b/DragonQuestino/string_util.h
@@ -1,0 +1,16 @@
+#if !defined( STRING_UTIL_H )
+#define STRING_UTIL_H
+
+#include "common.h"
+
+#if defined( __cplusplus )
+extern "C" {
+#endif
+
+void StringUtil_ToUpper( char* str );
+
+#if defined( __cplusplus )
+}
+#endif
+
+#endif // STRING_UTIL_H

--- a/DragonQuestinoWinDev/DragonQuestinoWinDev/DragonQuestinoWinDev.vcxproj
+++ b/DragonQuestinoWinDev/DragonQuestinoWinDev/DragonQuestinoWinDev.vcxproj
@@ -41,6 +41,7 @@
     <ClInclude Include="..\..\DragonQuestino\shop_picker.h" />
     <ClInclude Include="..\..\DragonQuestino\sprite.h" />
     <ClInclude Include="..\..\DragonQuestino\strings.h" />
+    <ClInclude Include="..\..\DragonQuestino\string_util.h" />
     <ClInclude Include="..\..\DragonQuestino\tables.h" />
     <ClInclude Include="..\..\DragonQuestino\tile_map.h" />
     <ClInclude Include="..\..\DragonQuestino\vector.h" />
@@ -73,6 +74,7 @@
     <ClCompile Include="..\..\DragonQuestino\dialog.c" />
     <ClCompile Include="..\..\DragonQuestino\shop_picker.c" />
     <ClCompile Include="..\..\DragonQuestino\sprite.c" />
+    <ClCompile Include="..\..\DragonQuestino\string_util.c" />
     <ClCompile Include="..\..\DragonQuestino\tile_map.c" />
     <ClCompile Include="win_clock.c" />
     <ClCompile Include="win_input.c" />

--- a/DragonQuestinoWinDev/DragonQuestinoWinDev/DragonQuestinoWinDev.vcxproj.filters
+++ b/DragonQuestinoWinDev/DragonQuestinoWinDev/DragonQuestinoWinDev.vcxproj.filters
@@ -96,6 +96,9 @@
     <ClInclude Include="..\..\DragonQuestino\shop_picker.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\DragonQuestino\string_util.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="win_clock.c">
@@ -192,6 +195,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\DragonQuestino\shop_picker.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\DragonQuestino\string_util.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Addresses Issue: #259 

## Overview

It's only for this one screen, but it really does look super goofy when the player's name has lower-case letters. I couldn't think of where to put a string util function in the existing files, so I just added a new file for it.