### PR TITLE
Bugfix: Restore the palette BEFORE resetting the game after the end

### DIFF
--- a/DragonQuestino/game_input.c
+++ b/DragonQuestino/game_input.c
@@ -680,6 +680,6 @@ internal void Game_EndingPauseCallback( Game_t* game )
 
 internal void Game_EndingPostFadeOutCallback( Game_t* game )
 {
-   Game_Reset( game );
    Screen_RestorePalette( &( game->screen ) );
+   Game_Reset( game );
 }


### PR DESCRIPTION
Addresses Issue: #260 

## Overview

This was actually a bigger problem than I thought. After beating the game, the "The End" screen fades out, after which I reset the game and restore the palette. But since resetting the game backs up the palette, I was essentially "restoring" a blank palette, so all the tilemaps after that are blank. This reverses the order, so we restore the palette FIRST, and THEN reset the game.