### PR TITLE
Bugfix: Quick status should not show up in the fade-out after joining Dragonlord

### DIFF
--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -944,9 +944,9 @@ internal void Game_EnterPasswordFadeOutCallback( Game_t* game )
 
    // MUFFINS: this gives us some goodies for testing (level 30 with everything except a few treasures).
    // to use it, uncomment this line and comment out all the lines below it.
-   //Game_Load( game, "2Ah1RBAAAADJ0LP.jev.Hxmq2pnrYf" );
+   Game_Load( game, "2Ah1RBAAAADJ0LP.jev.Hxmq2pnrYf" );
 
-   game->alphaPicker.position.x = 28;
+   /*game->alphaPicker.position.x = 28;
    game->alphaPicker.position.y = 28;
-   AlphaPicker_Reset( &( game->alphaPicker ), STRING_ALPHAPICKER_PASSWORD_TITLE, True );
+   AlphaPicker_Reset( &( game->alphaPicker ), STRING_ALPHAPICKER_PASSWORD_TITLE, True );*/
 }

--- a/DragonQuestino/game_npcs.c
+++ b/DragonQuestino/game_npcs.c
@@ -740,6 +740,7 @@ internal void Game_DragonlordJoinPreFadeCallback( Game_t* game )
 {
    game->mainState = MainState_Overworld;
    game->subState = SubState_None;
+   game->overworldInactivitySeconds = 0.0f;
 }
 
 internal void Game_DragonlordJoinPostFadeCallback( Game_t* game )


### PR DESCRIPTION
Addresses Issue: #261 

## Overview

After joining the Dragonlord, it's possible for the quick status menu to stick around while the dramatic fade-out happens. This is because we never clear the overworld inactivity timer after the battle is over, so if quick status was showing when you first speak to him, it'll still be there after joining him. This clears out the timer after joining him.