### PR TITLE
Bugfix: Allow the Dragonlord to initiate the fight

### DIFF
--- a/DragonQuestino/battle.c
+++ b/DragonQuestino/battle.c
@@ -591,8 +591,17 @@ internal void Battle_EnemyInitiativeCallback( Battle_t* battle )
    char msg[64];
 
    Dialog_Reset( &( battle->game->dialog ) );
-   sprintf( msg, STRING_BATTLE_ENEMYINITIATIVE, battle->enemy.name );
-   Dialog_PushSectionWithCallback( &( battle->game->dialog ), msg, Battle_EnemyInitiativeMessageCallback, battle );
+
+   if ( battle->enemy.id == ENEMY_DRAGONLORDWIZARD_ID || battle->enemy.id == ENEMY_DRAGONLORDDRAGON_ID )
+   {
+      Dialog_PushSectionWithCallback( &( battle->game->dialog ), STRING_BATTLE_DRAGONLORDINITIATIVE, Battle_EnemyInitiativeMessageCallback, battle );
+   }
+   else
+   {
+      sprintf( msg, STRING_BATTLE_ENEMYINITIATIVE, battle->enemy.name );
+      Dialog_PushSectionWithCallback( &( battle->game->dialog ), msg, Battle_EnemyInitiativeMessageCallback, battle );
+   }
+
    Game_OpenDialog( battle->game );
 }
 

--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -521,13 +521,27 @@ internal void Game_BattleIntroMessageCallback( Game_t* game )
 
    if ( game->battle.specialEnemy == SpecialEnemy_DragonlordWizard )
    {
-      sprintf( msg, STRING_BATTLE_DRAGONLORD_WIZARDINTRO );
-      Dialog_PushSectionWithCallback( &( game->dialog ), msg, Game_ResetBattleMenu, game );
+      if ( game->battle.turn == BattleTurn_Player )
+      {
+         sprintf( msg, STRING_BATTLE_DRAGONLORD_WIZARDINTRO );
+         Dialog_PushSectionWithCallback( &( game->dialog ), msg, Game_ResetBattleMenu, game );
+      }
+      else
+      {
+         Dialog_PushSectionWithCallback( &( game->dialog ), STRING_BATTLE_DRAGONLORD_WIZARDINTRO, Battle_EnemyInitiative, &( game->battle ) );
+      }
    }
    else if ( game->battle.specialEnemy == SpecialEnemy_DragonlordDragon )
    {
-      sprintf( msg, STRING_BATTLE_DRAGONLORD_DRAGONINTRO );
-      Dialog_PushSectionWithCallback( &( game->dialog ), msg, Game_ResetBattleMenu, game );
+      if ( game->battle.turn == BattleTurn_Player )
+      {
+         sprintf( msg, STRING_BATTLE_DRAGONLORD_DRAGONINTRO );
+         Dialog_PushSectionWithCallback( &( game->dialog ), msg, Game_ResetBattleMenu, game );
+      }
+      else
+      {
+         Dialog_PushSectionWithCallback( &( game->dialog ), STRING_BATTLE_DRAGONLORD_DRAGONINTRO, Battle_EnemyInitiative, &( game->battle ) );
+      }
    }
    else
    {

--- a/DragonQuestino/game_npcs.c
+++ b/DragonQuestino/game_npcs.c
@@ -7,7 +7,6 @@ internal void Game_DragonlordJoinCallback( Game_t* game );
 internal void Game_DragonlordJoinTransferCallback( Game_t* game );
 internal void Game_DragonlordJoinedCallback( Game_t* game );
 internal void Game_DragonlordJoinFadeCallback( Game_t* game );
-internal void Game_DragonlordJoinPreFadeCallback( Game_t* game );
 internal void Game_DragonlordJoinPostFadeCallback( Game_t* game );
 internal void Game_DragonlordRefuseCallback( Game_t* game );
 internal void Game_DragonlordRefuseMessageCallback( Game_t* game );
@@ -724,7 +723,7 @@ internal void Game_DragonlordJoinFadeCallback( Game_t* game )
       AnimationChain_PushAnimation( &( game->animationChain ), AnimationId_Pause );
    }
 
-   AnimationChain_PushAnimationWithCallback( &( game->animationChain ), AnimationId_Pause, Game_DragonlordJoinPreFadeCallback, game );
+   AnimationChain_PushAnimationWithCallback( &( game->animationChain ), AnimationId_Pause, Game_ChangeToOverworldState, game );
    AnimationChain_PushAnimation( &( game->animationChain ), AnimationId_SlowFadeOut );
 
    for ( i = 0; i < 10; i++ )
@@ -734,13 +733,6 @@ internal void Game_DragonlordJoinFadeCallback( Game_t* game )
 
    AnimationChain_PushAnimationWithCallback( &( game->animationChain ), AnimationId_Pause, Game_DragonlordJoinPostFadeCallback, game );
    AnimationChain_Start( &( game->animationChain ) );
-}
-
-internal void Game_DragonlordJoinPreFadeCallback( Game_t* game )
-{
-   game->mainState = MainState_Overworld;
-   game->subState = SubState_None;
-   game->overworldInactivitySeconds = 0.0f;
 }
 
 internal void Game_DragonlordJoinPostFadeCallback( Game_t* game )

--- a/DragonQuestino/strings.h
+++ b/DragonQuestino/strings.h
@@ -265,6 +265,7 @@
 #define STRING_BATTLE_ENEMYAPPROACHES                                "%s approaches!"
 #define STRING_BATTLE_ENEMYAPPROACHESINITIATIVE                      "%s approaches! Command?"
 #define STRING_BATTLE_ENEMYINITIATIVE                                "The %s gets the jump on you!"
+#define STRING_BATTLE_DRAGONLORDINITIATIVE                           "The Dragonlord launches a sneak attack!"
 #define STRING_BATTLE_ATTACKATTEMPT                                  "You attack!"
 #define STRING_BATTLE_ATTACKSUCCEEDED                                "The %s has lost %u hit %s."
 #define STRING_BATTLE_ATTACKEXCELLENTMOVE                            "Excellent move! The %s has lost %u hit %s."


### PR DESCRIPTION
Addresses Issue: #150 

## Overview

With the way battles are set up, it's possible for the enemy to get the initiative, but I wasn't accounting for that when it came to the Dragonlord. If either form of the Dragonlord happens to get the initiative, we just ignore that and the player gets two attacks in a row. This makes sure to account for both forms of the Dragonlord getting the jump on you.