### PR TITLE
Show attack and defense power in status

### DIFF
--- a/DragonQuestino/battle.c
+++ b/DragonQuestino/battle.c
@@ -223,18 +223,12 @@ internal u8 Battle_GetAttackDamage( Battle_t* battle )
 {
    Player_t* player = &( battle->game->player );
    Enemy_t* enemy = &( battle->enemy );
-   u8 power, defense, damage, minDamage = 0, maxDamage = 0;
+   u8 defense, damage, minDamage = 0, maxDamage = 0;
+   u8 power = Player_GetAttackPower( player );
 
    if ( !enemy->stats.isAsleep && enemy->stats.dodge > 0 && Random_u8( 1, 64 ) <= enemy->stats.dodge )
    {
       return 0;
-   }
-
-   power = player->stats.strength + player->weapon.effect;
-
-   if ( power < player->stats.strength ) // overflow
-   {
-      power = UINT8_MAX;
    }
 
    if ( ( battle->specialEnemy != SpecialEnemy_DragonlordWizard ) &&
@@ -832,21 +826,10 @@ internal void Battle_PlayerDefeatedPostDialogCallback( Battle_t* battle )
 
 internal u8 Battle_GetEnemyAttackDamage( Battle_t* battle )
 {
-   u8 defense, damage, minDamage = 0, maxDamage = 0;
+   u8 damage, minDamage = 0, maxDamage = 0;
    Enemy_t* enemy = &( battle->enemy );
    Player_t* player = &( battle->game->player );
-
-   defense = ( player->stats.agility / 2 ) + player->armor.effect + player->shield.effect;
-
-   if ( ITEM_HAS_DRAGONSCALE( player->items ) )
-   {
-      defense += 2;
-   }
-
-   if ( defense < ( player->stats.agility / 2 ) ) // overflow
-   {
-      defense = UINT8_MAX;
-   }
+   u8 defense = Player_GetDefensePower( player );
 
    if ( enemy->stats.strength > defense )
    {

--- a/DragonQuestino/game_render.c
+++ b/DragonQuestino/game_render.c
@@ -252,35 +252,41 @@ void Game_DrawQuickStatus( Game_t* game )
 void Game_DrawOverworldDeepStatus( Game_t* game )
 {
    // status window
-   Screen_DrawTextWindow( &( game->screen ), 80, 16, 20, 18 );
+   Screen_DrawTextWindow( &( game->screen ), 80, 16, 20, 19 );
    char line[18];
 
    sprintf( line, STRING_OVERWORLD_DEEPSTATS_NAME, game->player.name );
    Screen_DrawText( &( game->screen ), line, 104 + ( ( 4 - ( (u32)( ( strlen( game->player.name ) + 1 ) / 2 ) ) ) * TEXT_TILE_SIZE ), 24 );
 
    sprintf( line, STRING_OVERWORLD_DEEPSTATS_STRENGTH, game->player.stats.strength );
-   Screen_DrawText( &( game->screen ), line, 96, 40 );
+   Screen_DrawText( &( game->screen ), line, 96, 36 );
 
    sprintf( line, STRING_OVERWORLD_DEEPSTATS_AGILITY, game->player.stats.agility );
-   Screen_DrawText( &( game->screen ), line, 104, 56 );
+   Screen_DrawText( &( game->screen ), line, 104, 48 );
 
    sprintf( line, STRING_OVERWORLD_DEEPSTATS_MAXHP, game->player.stats.maxHitPoints );
-   Screen_DrawText( &( game->screen ), line, 112, 72 );
+   Screen_DrawText( &( game->screen ), line, 112, 60 );
 
    sprintf( line, STRING_OVERWORLD_DEEPSTATS_MAXMP, game->player.stats.maxMagicPoints );
-   Screen_DrawText( &( game->screen ), line, 112, 88 );
+   Screen_DrawText( &( game->screen ), line, 112, 72 );
 
-   Screen_DrawText( &( game->screen ), STRING_OVERWORLD_DEEPSTATS_WEAPON, 96, 104 );
-   Screen_DrawText( &( game->screen ), game->player.weapon.name1, 160, 104 );
-   Screen_DrawText( &( game->screen ), game->player.weapon.name2, 168, 112 );
+   sprintf( line, STRING_OVERWORLD_DEEPSTATS_ATTACK, Player_GetAttackPower( &( game->player ) ) );
+   Screen_DrawText( &( game->screen ), line, 112, 84 );
 
-   Screen_DrawText( &( game->screen ), STRING_OVERWORLD_DEEPSTATS_ARMOR, 104, 120 );
-   Screen_DrawText( &( game->screen ), game->player.armor.name1, 160, 120 );
-   Screen_DrawText( &( game->screen ), game->player.armor.name2, 168, 128 );
+   sprintf( line, STRING_OVERWORLD_DEEPSTATS_DEFENSE, Player_GetDefensePower( &( game->player ) ) );
+   Screen_DrawText( &( game->screen ), line, 104, 96 );
 
-   Screen_DrawText( &( game->screen ), STRING_OVERWORLD_DEEPSTATS_SHIELD, 96, 136 );
-   Screen_DrawText( &( game->screen ), game->player.shield.name1, 160, 136 );
-   Screen_DrawText( &( game->screen ), game->player.shield.name2, 168, 144 );
+   Screen_DrawText( &( game->screen ), STRING_OVERWORLD_DEEPSTATS_WEAPON, 96, 112 );
+   Screen_DrawText( &( game->screen ), game->player.weapon.name1, 160, 112 );
+   Screen_DrawText( &( game->screen ), game->player.weapon.name2, 168, 120 );
+
+   Screen_DrawText( &( game->screen ), STRING_OVERWORLD_DEEPSTATS_ARMOR, 104, 128 );
+   Screen_DrawText( &( game->screen ), game->player.armor.name1, 160, 128 );
+   Screen_DrawText( &( game->screen ), game->player.armor.name2, 168, 136 );
+
+   Screen_DrawText( &( game->screen ), STRING_OVERWORLD_DEEPSTATS_SHIELD, 96, 144 );
+   Screen_DrawText( &( game->screen ), game->player.shield.name1, 160, 144 );
+   Screen_DrawText( &( game->screen ), game->player.shield.name2, 168, 152 );
 
    // spells window
    Screen_DrawTextWindowWithTitle( &( game->screen ), 16, 168, 28, 6, STRING_OVERWORLD_DEEPSTATS_SPELLS );

--- a/DragonQuestino/player.c
+++ b/DragonQuestino/player.c
@@ -329,3 +329,32 @@ u16 Player_GetItemResellValue( u32 itemId )
 
    return 0;
 }
+
+u8 Player_GetAttackPower( Player_t* player )
+{
+   u8 power = player->stats.strength + player->weapon.effect;
+
+   if ( power < player->stats.strength ) // overflow
+   {
+      power = UINT8_MAX;
+   }
+
+   return power;
+}
+
+u8 Player_GetDefensePower( Player_t* player )
+{
+   u8 defense = ( player->stats.agility / 2 ) + player->armor.effect + player->shield.effect;
+
+   if ( ITEM_HAS_DRAGONSCALE( player->items ) )
+   {
+      defense += 2;
+   }
+
+   if ( defense < ( player->stats.agility / 2 ) ) // overflow
+   {
+      defense = UINT8_MAX;
+   }
+
+   return defense;
+}

--- a/DragonQuestino/player.h
+++ b/DragonQuestino/player.h
@@ -301,6 +301,8 @@ void Player_GetAccessoryName( Player_t* player, AccessoryType_t type, char* name
 u16 Player_GetAccessoryResellValue( Player_t* player, AccessoryType_t type );
 void Player_GetItemResellName( u32 itemId, char* name );
 u16 Player_GetItemResellValue( u32 itemId );
+u8 Player_GetAttackPower( Player_t* player );
+u8 Player_GetDefensePower( Player_t* player );
 
 #if defined( __cplusplus )
 }

--- a/DragonQuestino/strings.h
+++ b/DragonQuestino/strings.h
@@ -132,6 +132,8 @@
 #define STRING_OVERWORLD_DEEPSTATS_AGILITY                           "AGILITY: %u"
 #define STRING_OVERWORLD_DEEPSTATS_MAXHP                             "MAX HP: %u"
 #define STRING_OVERWORLD_DEEPSTATS_MAXMP                             "MAX MP: %u"
+#define STRING_OVERWORLD_DEEPSTATS_ATTACK                            "ATTACK: %u"
+#define STRING_OVERWORLD_DEEPSTATS_DEFENSE                           "DEFENSE: %u"
 #define STRING_OVERWORLD_DEEPSTATS_WEAPON                            "WEAPON:"
 #define STRING_OVERWORLD_DEEPSTATS_ARMOR                             "ARMOR:"
 #define STRING_OVERWORLD_DEEPSTATS_SHIELD                            "SHIELD:"


### PR DESCRIPTION
Addresses Issue: #230 

## Overview

The original game shows your attack and defense power on the deep-status screen, and I totally missed that. I had to scrunch the window, but I managed to add it while still keeping the spells:

<img width="193" height="192" alt="2025-10-02_17-28-08" src="https://github.com/user-attachments/assets/3cbf5fe9-a2c2-496d-9398-ffe2edc90cbb" />
