### PR TITLE
Bugfix: Weapon stores shouldn't allow selling

### DIFF
--- a/DragonQuestino/game_booths.c
+++ b/DragonQuestino/game_booths.c
@@ -455,7 +455,7 @@ internal void Game_FairyWaterShopLeaveCallback( Game_t* game )
 
 internal void Game_ShopLeaveOrStayCallback( Game_t* game )
 {
-   if ( ITEM_HAS_SELLABLE( game->player.items ) )
+   if ( game->tileMap.shopType == ShopType_Item && ITEM_HAS_SELLABLE( game->player.items ) )
    {
       BinaryPicker_Load( &( game->binaryPicker ),
                          STRING_BUY, STRING_SELL,


### PR DESCRIPTION
Addresses Issue: #278 

## Overview

This was a simple oversight, weapon and armor stores should not give you the option to sell (yet).