### PR TITLE
Bugfix: Don't wipe out the saved password

### DIFF
--- a/DragonQuestino/game.c
+++ b/DragonQuestino/game.c
@@ -132,7 +132,7 @@ void Game_Load( Game_t* game, const char* password )
       if ( Game_LoadFromPassword( game, password ) )
       {
          game->password[0] = 0;
-         game->lastPassword[0] = 0;
+         strcpy( game->lastPassword, password );
          game->gameFlags.leftThroneRoom = True;
       }
       else


### PR DESCRIPTION
Addresses Issue: #285 

## Overview

This is pretty bad, whenever you load a game from a password, we were wiping out the last password, so then every time you resize the screen it makes a save file with no password. This makes sure the last password is always up to date.