### PR TITLE
Bugfix: Adjust enemy attack damage calculation

### DIFF
--- a/DragonQuestino/battle.c
+++ b/DragonQuestino/battle.c
@@ -836,10 +836,6 @@ internal u8 Battle_GetEnemyAttackDamage( Battle_t* battle )
       minDamage = ( enemy->stats.strength - defense ) / 4;
       maxDamage = ( enemy->stats.strength - defense ) / 2;
    }
-   else
-   {
-      maxDamage = ( enemy->stats.strength + 4 ) / 6;
-   }
 
    damage = Random_u8( minDamage, maxDamage );
 


### PR DESCRIPTION
Addresses Issue: #292 

## Overview

I was right to think something was wrong, and I think this is a VERY significant update as far as grinding is concerned. The tech guide I was working from says we should do this if the player's defense is greater than or equal to the enemy's attack power:

`(enemyStrength + 4) / 6`

But this is nuts, it allows enemies much weaker than you to inflict crazy amounts of damage. I don't know if this is what the original game actually does, but I just straight up got rid of it, so now it's equalized. If you're stronger than the enemy, they have a 50/50 chance of causing 1 damage (unless you're asleep, in which case they'll always cause 1 damage).