### PR TITLE
Bugfix: end-game Tantegel soldier wander pattern

### DIFF
--- a/DragonQuestino/game_data.c
+++ b/DragonQuestino/game_data.c
@@ -54363,7 +54363,7 @@ void TileMap_Load( TileMap_t* tileMap, uint32_t id )
          tileMap->npcs[9].wanders = True;
          tileMap->npcs[9].isWandering = False;
          tileMap->npcs[9].wanderBounds.x = 17;
-         tileMap->npcs[9].wanderBounds.y = 4;
+         tileMap->npcs[9].wanderBounds.y = 2;
          tileMap->npcs[9].wanderBounds.w = 5;
          tileMap->npcs[9].wanderBounds.h = 5;
          tileMap->npcs[10].id = 19;


### PR DESCRIPTION
Addresses Issue: #294 

## Overview

After beating the game, there was soldier in Tantegel Castle that still had an incorrect wander pattern, this fixes that.